### PR TITLE
Seperate histogram send frequency

### DIFF
--- a/core/src/main/scala/zio/metrics/connectors/datadog/DataDogEventProcessor.scala
+++ b/core/src/main/scala/zio/metrics/connectors/datadog/DataDogEventProcessor.scala
@@ -29,7 +29,7 @@ object DataDogEventProcessor {
                            }
                          }
                          .ignoreLogged
-                         .schedule(Schedule.fixed(metricsConfig.interval))
+                         .schedule(Schedule.fixed(datadogConfig.histogramSendInterval.getOrElse(metricsConfig.interval)))
                          .forkDaemon
                          .unit
     } yield ()

--- a/core/src/main/scala/zio/metrics/connectors/datadog/DatadogConfig.scala
+++ b/core/src/main/scala/zio/metrics/connectors/datadog/DatadogConfig.scala
@@ -1,11 +1,28 @@
 package zio.metrics.connectors.datadog
 
-import zio._
+import java.time.Duration
+
 import zio.{ULayer, ZLayer}
 
+/**
+ * Datadog Specific configuration
+ * @param host
+ *  Agent host name
+ * @param port
+ *  Agent port
+ * @param histogramSendInterval
+ *  Override for when the distributions should be sent faster than the general metrics frequency.
+ *  This is typically with an app that generates lots of distributions, but doesn't want to send other metrics
+ *  types, such as gauges, too frequently
+ * @param maxBatchedMetrics
+ *  The maximum number of metrics to batch before sending. This affects packet size
+ * @param maxQueueSize
+ *  The maximum number of metrics stored in the queue. This affects memory usage
+ */
 final case class DatadogConfig(
   host: String,
   port: Int,
+  histogramSendInterval: Option[Duration] = None,
   maxBatchedMetrics: Int = 10,
   maxQueueSize: Int = 100000)
 
@@ -15,6 +32,7 @@ object DatadogConfig {
     DatadogConfig(
       host = "localhost",
       port = 8125,
+      histogramSendInterval = None,
     )
 
   val defaultLayer: ULayer[DatadogConfig] = ZLayer.succeed(default)

--- a/core/src/main/scala/zio/metrics/connectors/newrelic/package.scala
+++ b/core/src/main/scala/zio/metrics/connectors/newrelic/package.scala
@@ -33,13 +33,12 @@ package object newrelic {
     }
 
     val send = ZIO
-      .foreach(events.filter(evtFilter))(evt =>
+      .foreachDiscard(events.filter(evtFilter))(evt =>
         for {
           encoded <- encoder.encode(evt).catchAll(_ => ZIO.succeed(Chunk.empty))
           _       <- ZIO.when(encoded.nonEmpty)(client.send(encoded))
         } yield (),
       )
-      .unit
 
     send
 

--- a/core/src/main/scala/zio/metrics/connectors/statsd/package.scala
+++ b/core/src/main/scala/zio/metrics/connectors/statsd/package.scala
@@ -17,13 +17,12 @@ package object statsd {
     }
 
     val send = ZIO
-      .foreach(events.filter(evtFilter))(evt =>
+      .foreachDiscard(events.filter(evtFilter))(evt =>
         for {
           encoded <- StatsdEncoder.encode(evt).catchAll(_ => ZIO.succeed(Chunk.empty))
           _       <- ZIO.when(encoded.nonEmpty)(ZIO.attempt(clt.send(encoded)))
         } yield (),
       )
-      .unit
 
     // TODO: Do we want to at least log a problem sending the metrics ?
     send.catchAll(_ => ZIO.unit)


### PR DESCRIPTION
Typically services want to send metrics at 1, 5, 10, 30 second intervals to minimise storage space. However with distribution metrics, each metric needs sending as they are not sampled. In a high throughput service it is undesirable to store 1000's of metrics waiting when using a low metrics frequency. It consumes memory and makes the service very "bursty", where it sends thousands of metrics with no gap, then pauses for n seconds. 

An alternative is to increase the metrics frequency to something like 100ms, which suits the distribution sending, but this causes _all_ the metrics to be queried and sent. There is some suppression of sending metrics that have not changed, but many metrics, such as `zio_fiber_fork_locations` get updated continuously, but there is little value in having the data at sub-second resolution.

This PR is one approach to decoupling the histogram sending frequency whilst maintaining backward compatibility. I welcome feedback on the approach and welcome suggestions of a better way. @petoalbert, I would value your opinion too!

There are also some small performance optimizations + document updates