### PR TITLE
Configurable HELP string for Prometheus metrics

### DIFF
--- a/core/src/main/scala/zio/metrics/connectors/MetricsConfig.scala
+++ b/core/src/main/scala/zio/metrics/connectors/MetricsConfig.scala
@@ -3,4 +3,12 @@ package zio.metrics.connectors
 import java.time.Duration
 
 final case class MetricsConfig(
-  interval: Duration)
+  /**
+   * Interval for polling metrics registry.
+   */
+  interval: Duration,
+
+  /**
+   * Key name for MetricLabel used as description (currently in Prometheus connector only).
+   */
+  descriptionKey: String = "description")

--- a/core/src/main/scala/zio/metrics/connectors/prometheus/package.scala
+++ b/core/src/main/scala/zio/metrics/connectors/prometheus/package.scala
@@ -9,18 +9,26 @@ package object prometheus {
 
   lazy val prometheusLayer: ZLayer[MetricsConfig & PrometheusPublisher, Nothing, Unit] =
     ZLayer.fromZIO(
-      ZIO.service[PrometheusPublisher].flatMap(clt => MetricsClient.make(prometheusHandler(clt))).unit,
+      for {
+        conf <- ZIO.service[MetricsConfig]
+        pub  <- ZIO.service[PrometheusPublisher]
+        _    <- MetricsClient.make(prometheusHandler(pub, conf))
+      } yield (),
     )
 
-  private def prometheusHandler(clt: PrometheusPublisher): Iterable[MetricEvent] => UIO[Unit] = events =>
-    for {
-      reportComplete <- ZIO.foreach(events)(evt =>
-                          for {
-                            reportEvent <-
-                              PrometheusEncoder.encode(evt).map(_.mkString("\n")).catchAll(_ => ZIO.succeed(""))
-                          } yield reportEvent,
-                        )
-      _              <- clt.set(reportComplete.mkString("\n"))
-    } yield ()
+  private def prometheusHandler(clt: PrometheusPublisher, config: MetricsConfig): Iterable[MetricEvent] => UIO[Unit] =
+    events =>
+      for {
+        reportComplete <- ZIO.foreach(events)(evt =>
+                            for {
+                              reportEvent <-
+                                PrometheusEncoder
+                                  .encode(evt, descriptionKey = Some(config.descriptionKey))
+                                  .map(_.mkString("\n"))
+                                  .catchAll(_ => ZIO.succeed(""))
+                            } yield reportEvent,
+                          )
+        _              <- clt.set(reportComplete.mkString("\n"))
+      } yield ()
 
 }

--- a/core/src/test/scala/sample/InstrumentedSample.scala
+++ b/core/src/test/scala/sample/InstrumentedSample.scala
@@ -1,4 +1,4 @@
-package sample
+package zio.sample
 
 import zio._
 import zio.metrics._
@@ -6,7 +6,7 @@ import zio.metrics._
 trait InstrumentedSample {
 
   // Create a gauge, it can be applied to effects yielding a Double
-  val aspGauge1 = Metric.gauge("gauge1")
+  val aspGauge1 = Metric.gauge("gauge1").tagged("description", "Sample gauge1")
 
   val aspGauge2 = Metric.gauge("gauge2")
 

--- a/core/src/test/scala/sample/SampleApp.scala
+++ b/core/src/test/scala/sample/SampleApp.scala
@@ -1,4 +1,4 @@
-package sample
+package zio.sample
 
 import java.net.InetSocketAddress
 

--- a/core/src/test/scala/zio/metrics/connectors/Generators.scala
+++ b/core/src/test/scala/zio/metrics/connectors/Generators.scala
@@ -14,51 +14,63 @@ trait Generators {
 
   val nonEmptyString = Gen.alphaNumericString.filter(_.nonEmpty)
 
+  val descriptionKey = "testDescription"
+
+  val genLabel =
+    Gen.oneOf(Gen.const(descriptionKey), Gen.alphaNumericString).zipWith(Gen.alphaNumericString)(MetricLabel.apply)
+
+  val genTags = Gen.setOf(genLabel)
+
   val genCounter = for {
     name  <- nonEmptyString
+    tags  <- genTags
     count <- Gen.double(1, 100)
   } yield {
     val state = MetricState.Counter(count)
-    (Unsafe.unsafe(implicit u => MetricPair.make(MetricKey.counter(name), state)), state)
+    (Unsafe.unsafe(implicit u => MetricPair.make(MetricKey.counter(name).tagged(tags), state)), state)
   }
 
   def genCounterNamed(name: String, min: Double = 1.0, max: Double = 100) = for {
     count <- Gen.double(min, max)
+    tags  <- genTags
   } yield {
     val state = MetricState.Counter(count)
-    (Unsafe.unsafe(implicit u => MetricPair.make(MetricKey.counter(name), state)), state)
+    (Unsafe.unsafe(implicit u => MetricPair.make(MetricKey.counter(name).tagged(tags), state)), state)
   }
 
   def genFrequency(count: Int, pastValues: Ref[Set[String]]) = for {
     name        <- nonEmptyString
+    tags        <- genTags
     occurrences <- Gen.listOfN(count)(unqiueNonEmptyString(pastValues).flatMap(occName => genPosLong.map(occName -> _)))
   } yield {
     val asMap = occurrences.toMap
     val state = MetricState.Frequency(asMap)
-    (Unsafe.unsafe(implicit u => MetricPair.make(MetricKey.frequency(name), state)), state)
+    (Unsafe.unsafe(implicit u => MetricPair.make(MetricKey.frequency(name).tagged(tags), state)), state)
   }
 
   val genFrequency1 = for {
     name    <- nonEmptyString
+    tags    <- genTags
     occName <- nonEmptyString
     count   <- genPosLong
   } yield {
-
     val asMap = Map(occName -> count)
     val state = MetricState.Frequency(asMap)
-    (Unsafe.unsafe(implicit u => MetricPair.make(MetricKey.frequency(name), state)), state)
+    (Unsafe.unsafe(implicit u => MetricPair.make(MetricKey.frequency(name).tagged(tags), state)), state)
   }
 
   val genGauge: Gen[Any, (Untyped, MetricState.Gauge)] = for {
     name  <- nonEmptyString
+    tags  <- genTags
     count <- genPosDouble
   } yield {
     val state = MetricState.Gauge(count)
-    (Unsafe.unsafe(implicit u => MetricPair.make(MetricKey.counter(name), state)), state)
+    (Unsafe.unsafe(implicit u => MetricPair.make(MetricKey.counter(name).tagged(tags), state)), state)
   }
 
   def genHistogram = for {
     name  <- nonEmptyString
+    tags  <- genTags
     count <- genPosLong
     min   <- Gen.double
     max   <- Gen.double.filter(_ >= min)
@@ -80,11 +92,12 @@ trait Generators {
       (Double.MaxValue, 10L),
     )
     val state      = MetricState.Histogram(buckets, count, min, max, sum)
-    (Unsafe.unsafe(implicit u => MetricPair.make(MetricKey.histogram(name, boundaries), state)), state)
+    (Unsafe.unsafe(implicit u => MetricPair.make(MetricKey.histogram(name, boundaries).tagged(tags), state)), state)
   }
 
   def genSummary = for {
     name      <- nonEmptyString
+    tags      <- genTags
     count     <- genPosLong
     min       <- Gen.double
     max       <- Gen.double.filter(_ >= min)
@@ -97,7 +110,7 @@ trait Generators {
     val state = MetricState.Summary(error, quantiles, count, min, max, sum)
     (
       Unsafe.unsafe(implicit u =>
-        MetricPair.make(MetricKey.summary(name, maxAge, maxSize, error, quantiles.map(_._1)), state),
+        MetricPair.make(MetricKey.summary(name, maxAge, maxSize, error, quantiles.map(_._1)).tagged(tags), state),
       ),
       state,
     )

--- a/core/src/test/scala/zio/metrics/connectors/prometheus/PrometheusEncoderSpec.scala
+++ b/core/src/test/scala/zio/metrics/connectors/prometheus/PrometheusEncoderSpec.scala
@@ -1,6 +1,7 @@
 package zio.metrics.connectors.prometheus
 
 import zio._
+import zio.metrics.{MetricKey, MetricLabel}
 import zio.metrics.connectors._
 import zio.metrics.connectors.MetricEvent._
 import zio.test._
@@ -16,16 +17,27 @@ object PrometheusEncoderSpec extends ZIOSpecDefault with Generators {
     encodeHistogram,
   ) @@ timed @@ timeoutWarning(60.seconds) @@ parallel @@ withLiveClock
 
+  private def helpString(key: MetricKey.Untyped) =
+    key.tags.find(_.key == descriptionKey).fold("")(d => s" ${d.value}")
+
+  private def labelString(key: MetricKey.Untyped, extra: (String, String)*) = {
+    val tags = key.tags.filter(_.key != descriptionKey) ++ extra.map(x => MetricLabel(x._1, x._2)).toSet
+    if (tags.isEmpty) ""
+    else tags.map(l => s"""${l.key}="${l.value}"""").mkString("{", ",", "}")
+  }
+
   private val encodeCounter = test("Encode a Counter")(check(genCounter) { case (pair, state) =>
     for {
       timestamp <- ZIO.clockWith(_.instant)
-      text      <- PrometheusEncoder.encode(New(pair.metricKey, state, timestamp))
+      text      <- PrometheusEncoder.encode(New(pair.metricKey, state, timestamp), Some(descriptionKey))
       name       = pair.metricKey.name
+      help       = helpString(pair.metricKey)
+      labels     = labelString(pair.metricKey)
     } yield assertTrue(
       text == Chunk(
         s"# TYPE $name counter",
-        s"# HELP $name Some help",
-        s"$name ${state.count} ${timestamp.toEpochMilli}",
+        s"# HELP $name$help",
+        s"$name$labels ${state.count} ${timestamp.toEpochMilli}",
       ),
     )
   })
@@ -33,13 +45,15 @@ object PrometheusEncoderSpec extends ZIOSpecDefault with Generators {
   private val encodeGauge = test("Encode a Gauge")(check(genGauge) { case (pair, state) =>
     for {
       timestamp <- ZIO.clockWith(_.instant)
-      text      <- PrometheusEncoder.encode(New(pair.metricKey, state, timestamp))
+      text      <- PrometheusEncoder.encode(New(pair.metricKey, state, timestamp), Some(descriptionKey))
       name       = pair.metricKey.name
+      help       = helpString(pair.metricKey)
+      labels     = labelString(pair.metricKey)
     } yield assertTrue(
       text == Chunk(
         s"# TYPE $name gauge",
-        s"# HELP $name Some help",
-        s"$name ${state.value} ${timestamp.toEpochMilli}",
+        s"# HELP $name$help",
+        s"$name$labels ${state.value} ${timestamp.toEpochMilli}",
       ),
     )
   })
@@ -47,13 +61,15 @@ object PrometheusEncoderSpec extends ZIOSpecDefault with Generators {
   private val encodeFrequency = test("Encode a Frequency")(check(genFrequency1) { case (pair, state) =>
     for {
       timestamp <- ZIO.clockWith(_.instant)
-      text      <- PrometheusEncoder.encode(New(pair.metricKey, state, timestamp))
+      text      <- PrometheusEncoder.encode(New(pair.metricKey, state, timestamp), Some(descriptionKey))
       name       = pair.metricKey.name
+      help       = helpString(pair.metricKey)
       expected   = Chunk.fromIterable(state.occurrences).flatMap { case (k, v) =>
+                     val labels = labelString(pair.metricKey, "bucket" -> k)
                      Chunk(
                        s"# TYPE $name counter",
-                       s"# HELP $name Some help",
-                       s"""$name{bucket="$k"} ${v.toDouble} ${timestamp.toEpochMilli}""",
+                       s"# HELP $name$help",
+                       s"""$name$labels ${v.toDouble} ${timestamp.toEpochMilli}""",
                      )
                    }
     } yield assertTrue(text == expected)
@@ -62,42 +78,49 @@ object PrometheusEncoderSpec extends ZIOSpecDefault with Generators {
   private val encodeSummary = test("Encode a Summary")(check(genSummary) { case (pair, state) =>
     for {
       timestamp <- ZIO.clockWith(_.instant)
-      text      <- PrometheusEncoder.encode(New(pair.metricKey, state, timestamp))
+      text      <- PrometheusEncoder.encode(New(pair.metricKey, state, timestamp), Some(descriptionKey))
       name       = pair.metricKey.name
       epochMilli = timestamp.toEpochMilli
+      help       = helpString(pair.metricKey)
+      labels     = labelString(pair.metricKey)
     } yield assertTrue(
       text == Chunk(
         s"# TYPE $name summary",
-        s"# HELP $name Some help",
+        s"# HELP $name$help",
       ) ++ state.quantiles.map { case (k, v) =>
-        s"""$name{quantile="$k",error="${state.error}"} ${v.getOrElse(Double.NaN)} $epochMilli"""
+        val labelsWithExtra = labelString(pair.metricKey, "quantile" -> k.toString, "error" -> state.error.toString)
+        s"""$name$labelsWithExtra ${v.getOrElse(Double.NaN)} $epochMilli"""
       } ++ Chunk(
-        s"${name}_sum ${state.sum} $epochMilli",
-        s"${name}_count ${state.count.toDouble} $epochMilli",
-        s"${name}_min ${state.min} $epochMilli",
-        s"${name}_max ${state.max} $epochMilli",
+        s"${name}_sum$labels ${state.sum} $epochMilli",
+        s"${name}_count$labels ${state.count.toDouble} $epochMilli",
+        s"${name}_min$labels ${state.min} $epochMilli",
+        s"${name}_max$labels ${state.max} $epochMilli",
       ),
     )
   })
 
   private val encodeHistogram = test("Encode a Histogram")(check(genHistogram) { case (pair, state) =>
     for {
-      timestamp <- ZIO.clockWith(_.instant)
-      text      <- PrometheusEncoder.encode(New(pair.metricKey, state, timestamp))
-      name       = pair.metricKey.name
-      epochMilli = timestamp.toEpochMilli
+      timestamp    <- ZIO.clockWith(_.instant)
+      text         <- PrometheusEncoder.encode(New(pair.metricKey, state, timestamp), Some(descriptionKey))
+      name          = pair.metricKey.name
+      epochMilli    = timestamp.toEpochMilli
+      help          = helpString(pair.metricKey)
+      labels        = labelString(pair.metricKey)
+      labelsWithInf = labelString(pair.metricKey, "le" -> "+Inf")
     } yield assertTrue(
       text == Chunk(
         s"# TYPE $name histogram",
-        s"# HELP $name Some help",
+        s"# HELP $name$help",
       ) ++ state.buckets.filter(_._1 < Double.MaxValue).map { case (k, v) =>
-        s"""${name}_bucket{le="$k"} ${v.toDouble} $epochMilli"""
+        val labelsWithExtra = labelString(pair.metricKey, "le" -> k.toString)
+        s"""${name}_bucket$labelsWithExtra ${v.toDouble} $epochMilli"""
       } ++ Chunk(
-        s"""${name}_bucket{le="+Inf"} ${state.count.toDouble} $epochMilli""",
-        s"${name}_sum ${state.sum} $epochMilli",
-        s"${name}_count ${state.count.toDouble} $epochMilli",
-        s"${name}_min ${state.min} $epochMilli",
-        s"${name}_max ${state.max} $epochMilli",
+        s"""${name}_bucket$labelsWithInf ${state.count.toDouble} $epochMilli""",
+        s"${name}_sum$labels ${state.sum} $epochMilli",
+        s"${name}_count$labels ${state.count.toDouble} $epochMilli",
+        s"${name}_min$labels ${state.min} $epochMilli",
+        s"${name}_max$labels ${state.max} $epochMilli",
       ),
     )
   })


### PR DESCRIPTION
Closes #23. According to discussion in https://github.com/zio/zio/pull/7781 we don't add additional operators  to `zio.metrics.MetricKey` and just use one of `tags` as description. The name of key used as description is configurable.
