### PR TITLE
Support for DogStatsD container ID

### DIFF
--- a/core/src/main/scala/zio/metrics/connectors/datadog/DatadogConfig.scala
+++ b/core/src/main/scala/zio/metrics/connectors/datadog/DatadogConfig.scala
@@ -18,13 +18,16 @@ import zio.{ULayer, ZLayer}
  *  The maximum number of metrics to batch before sending. This affects packet size
  * @param maxQueueSize
  *  The maximum number of metrics stored in the queue. This affects memory usage
+ * @param containerId
+ *  An optional docker container ID
  */
 final case class DatadogConfig(
   host: String,
   port: Int,
   histogramSendInterval: Option[Duration] = None,
   maxBatchedMetrics: Int = 10,
-  maxQueueSize: Int = 100000)
+  maxQueueSize: Int = 100000,
+  containerId: Option[String] = None)
 
 object DatadogConfig {
 

--- a/core/src/main/scala/zio/metrics/connectors/datadog/DatadogEncoder.scala
+++ b/core/src/main/scala/zio/metrics/connectors/datadog/DatadogEncoder.scala
@@ -14,7 +14,7 @@ case object DatadogEncoder {
     val withContainerId = config.containerId match {
       case Some(cid) =>
         val s = cidString(cid)
-        event: MetricEvent => base(event).append(s)
+        (event: MetricEvent) => base(event).append(s)
       case None      =>
         base
     }

--- a/core/src/main/scala/zio/metrics/connectors/datadog/DatadogEncoder.scala
+++ b/core/src/main/scala/zio/metrics/connectors/datadog/DatadogEncoder.scala
@@ -2,20 +2,44 @@ package zio.metrics.connectors.datadog
 
 import zio._
 import zio.metrics._
+import zio.metrics.connectors.MetricEvent
 import zio.metrics.connectors.statsd.StatsdEncoder
 
 case object DatadogEncoder {
 
   private val BUF_PER_METRIC = 128
 
-  def encodeHistogramValues(
-    key: MetricKey[MetricKeyType.Histogram],
-    values: NonEmptyChunk[Double],
-  ): Chunk[Byte] = {
-    val result = new scala.collection.mutable.StringBuilder(BUF_PER_METRIC)
-
-    StatsdEncoder.appendMetric(result, key.name, values, "d", key.tags)
-
-    Chunk.fromArray(result.toString().getBytes())
+  def encoder(config: DatadogConfig): MetricEvent => Task[Chunk[Byte]] = {
+    val base = StatsdEncoder.encodeEvent _
+    val withContainerId = config.containerId match {
+      case Some(cid) =>
+        val s = cidString(cid)
+        event: MetricEvent => base(event).append(s)
+      case None =>
+        base
+    }
+    event => ZIO.attempt(Chunk.fromArray(withContainerId(event).toString().getBytes()))
   }
+
+  def histogramEncoder(config: DatadogConfig): (MetricKey[MetricKeyType.Histogram], NonEmptyChunk[Double]) => Chunk[Byte] = {
+
+    def encodeHistogramValues(key: MetricKey[MetricKeyType.Histogram],
+                              values: NonEmptyChunk[Double]): StringBuilder = {
+      val result = new StringBuilder(BUF_PER_METRIC)
+      StatsdEncoder.appendMetric(result, key.name, values, "d", key.tags)
+    }
+
+    val base = encodeHistogramValues _
+    val withContainerId = config.containerId match {
+      case Some(cid) =>
+        val s = cidString(cid)
+        (key: MetricKey[MetricKeyType.Histogram], values: NonEmptyChunk[Double]) =>
+          base(key, values).append(s)
+      case None =>
+        base
+    }
+    (key, values) => Chunk.fromArray(withContainerId(key, values).toString().getBytes())
+  }
+
+  private def cidString(cid: String) = s"|c:$cid"
 }

--- a/core/src/main/scala/zio/metrics/connectors/datadog/package.scala
+++ b/core/src/main/scala/zio/metrics/connectors/datadog/package.scala
@@ -1,16 +1,12 @@
 package zio.metrics.connectors
 
-import zio.{metrics, _}
+import zio._
 import zio.internal.RingBuffer
-import zio.metrics.{MetricClient, MetricKey, MetricKeyType}
 import zio.metrics.connectors.internal.MetricsClient
-import zio.metrics.connectors.statsd.StatsdClient
-import zio.metrics.connectors.statsd.StatsdConfig
+import zio.metrics.connectors.statsd.{StatsdClient, StatsdConfig}
+import zio.metrics.{MetricClient, MetricKey, MetricKeyType}
 
 package object datadog {
-
-  def statsdHandler(client: StatsdClient): Iterable[MetricEvent] => UIO[Unit] = events =>
-    statsd.statsdHandler(client)(events.filter(!_.metricKey.keyType.isInstanceOf[metrics.MetricKeyType.Histogram]))
 
   lazy val datadogLayer: ZLayer[DatadogConfig & MetricsConfig, Nothing, Unit] =
     ZLayer.scoped(
@@ -25,7 +21,27 @@ package object datadog {
                      ),
                    )
         _       <- DataDogEventProcessor.make(clt, queue)
-        _       <- MetricsClient.make(statsdHandler(clt))
+        _       <- MetricsClient.make(datadogHandler(clt, config))
       } yield (),
     )
+
+  private[connectors] def datadogHandler(client: StatsdClient, config: DatadogConfig): Iterable[MetricEvent] => UIO[Unit] = events => {
+    val evtFilter: MetricEvent => Boolean = {
+      case MetricEvent.Unchanged(_, _, _) => false
+      case _ => true
+    }
+
+    val encoder = DatadogEncoder.encoder(config)
+
+    val send = ZIO
+      .foreachDiscard(events.filter(evtFilter))(evt =>
+        for {
+          encoded <- encoder(evt).catchAll(_ => ZIO.succeed(Chunk.empty))
+          _ <- ZIO.when(encoded.nonEmpty)(ZIO.attempt(client.send(encoded)))
+        } yield (),
+      )
+
+    send.ignore
+  }
+
 }

--- a/core/src/main/scala/zio/metrics/connectors/statsd/StatsdEncoder.scala
+++ b/core/src/main/scala/zio/metrics/connectors/statsd/StatsdEncoder.scala
@@ -11,11 +11,11 @@ case object StatsdEncoder {
   private val BUF_PER_METRIC = 128
 
   def encode(event: MetricEvent): Task[Chunk[Byte]] =
-    ZIO.attempt(encodeEvent(event))
+    ZIO.attempt(Chunk.fromArray(encodeEvent(event).toString().getBytes()))
 
   def encodeEvent(
     event: MetricEvent,
-  ): Chunk[Byte] = {
+  ): StringBuilder = {
 
     val result = new StringBuilder(BUF_PER_METRIC)
 
@@ -27,7 +27,7 @@ case object StatsdEncoder {
       case f: MetricState.Frequency => appendFrequency(result, event.metricKey, f)
     }
 
-    Chunk.fromArray(result.toString().getBytes())
+    result
   }
 
   // TODO: We need to determine the delta for the counter since we have last reported it

--- a/core/src/test/scala/zio/metrics/connectors/datadog/DatadogEncoderSpec.scala
+++ b/core/src/test/scala/zio/metrics/connectors/datadog/DatadogEncoderSpec.scala
@@ -1,14 +1,14 @@
 package zio.metrics.connectors.datadog
 
+import java.time.Instant
+
 import zio._
-import zio.metrics.MetricKeyType.Histogram.Boundaries
 import zio.metrics._
+import zio.metrics.MetricKeyType.Histogram.Boundaries
 import zio.metrics.connectors.MetricEvent
+import zio.test._
 import zio.test.Assertion._
 import zio.test.TestAspect._
-import zio.test._
-
-import java.time.Instant
 
 object DatadogEncoderSpec extends ZIOSpecDefault {
 
@@ -16,7 +16,7 @@ object DatadogEncoderSpec extends ZIOSpecDefault {
     sendHistogram,
     sendHistograms,
     encodeContainerId,
-    encodeHistogramWithContainerId
+    encodeHistogramWithContainerId,
   ) @@ timed @@ timeoutWarning(60.seconds)
 
   private val sendHistogram = test("send histogram update") {
@@ -46,7 +46,7 @@ object DatadogEncoderSpec extends ZIOSpecDefault {
     val event       = MetricEvent.New(MetricKey.gauge(name), MetricState.Gauge(1), Instant.now())
     for {
       encoded <- encoder(event)
-      s       = new String(encoded.toArray)
+      s        = new String(encoded.toArray)
     } yield assert(s)(equalTo(s"$name:1|g|c:$containerId"))
   }
 

--- a/core/src/test/scala/zio/metrics/connectors/datadog/DatadogEncoderSpec.scala
+++ b/core/src/test/scala/zio/metrics/connectors/datadog/DatadogEncoderSpec.scala
@@ -1,26 +1,31 @@
 package zio.metrics.connectors.datadog
 
 import zio._
-import zio.metrics._
 import zio.metrics.MetricKeyType.Histogram.Boundaries
-import zio.metrics.connectors.datadog.DatadogEncoder
-import zio.test._
+import zio.metrics._
+import zio.metrics.connectors.MetricEvent
 import zio.test.Assertion._
 import zio.test.TestAspect._
+import zio.test._
+
+import java.time.Instant
 
 object DatadogEncoderSpec extends ZIOSpecDefault {
 
   override def spec = suite("The Datadog encoder should")(
     sendHistogram,
     sendHistograms,
+    encodeContainerId,
+    encodeHistogramWithContainerId
   ) @@ timed @@ timeoutWarning(60.seconds)
 
   private val sendHistogram = test("send histogram update") {
     val name     = "testHistogram"
     val tagName  = "testTag"
     val tagValue = "tagValue"
+    val encoder  = DatadogEncoder.histogramEncoder(DatadogConfig.default)
     val key      = MetricKey.histogram(name, Boundaries(Chunk.empty)).tagged(tagName, tagValue)
-    val encoded  = new String(DatadogEncoder.encodeHistogramValues(key, NonEmptyChunk(1.0)).toArray)
+    val encoded  = new String(encoder(key, NonEmptyChunk(1.0)).toArray)
     assert(encoded)(equalTo(s"$name:1|d|#$tagName:$tagValue"))
   }
 
@@ -28,8 +33,32 @@ object DatadogEncoderSpec extends ZIOSpecDefault {
     val name     = "testHistogram"
     val tagName  = "testTag"
     val tagValue = "tagValue"
+    val encoder  = DatadogEncoder.histogramEncoder(DatadogConfig.default)
     val key      = MetricKey.histogram(name, Boundaries(Chunk.empty)).tagged(tagName, tagValue)
-    val encoded  = new String(DatadogEncoder.encodeHistogramValues(key, NonEmptyChunk(1.0, 2.0)).toArray)
+    val encoded  = new String(encoder(key, NonEmptyChunk(1.0, 2.0)).toArray)
     assert(encoded)(equalTo(s"$name:1:2|d|#$tagName:$tagValue"))
   }
+
+  private val encodeContainerId = test("encode container ID") {
+    val containerId = "aaa"
+    val name        = "m1"
+    val encoder     = DatadogEncoder.encoder(DatadogConfig.default.copy(containerId = Some(containerId)))
+    val event       = MetricEvent.New(MetricKey.gauge(name), MetricState.Gauge(1), Instant.now())
+    for {
+      encoded <- encoder(event)
+      s       = new String(encoded.toArray)
+    } yield assert(s)(equalTo(s"$name:1|g|c:$containerId"))
+  }
+
+  private val encodeHistogramWithContainerId = test("encode histogram with container ID") {
+    val containerId = "aaa"
+    val name        = "testHistogram"
+    val tagName     = "testTag"
+    val tagValue    = "tagValue"
+    val encoder     = DatadogEncoder.histogramEncoder(DatadogConfig.default.copy(containerId = Some(containerId)))
+    val key         = MetricKey.histogram(name, Boundaries(Chunk.empty)).tagged(tagName, tagValue)
+    val encoded     = new String(encoder(key, NonEmptyChunk(1.0, 2.0)).toArray)
+    assert(encoded)(equalTo(s"$name:1:2|d|#$tagName:$tagValue|c:$containerId"))
+  }
+
 }


### PR DESCRIPTION
[DogStatsD protocol v1.2](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#dogstatsd-protocol-v12) added an optional docker container ID tag. This PR adds adds that ability to the Datadog connector