### PR TITLE
#34 Adhere to Prometheus Exposition format

### DIFF
--- a/core/src/main/scala/zio/metrics/connectors/prometheus/package.scala
+++ b/core/src/main/scala/zio/metrics/connectors/prometheus/package.scala
@@ -30,7 +30,7 @@ package object prometheus {
       } yield ()
 
   def groupMetricByType(report: Chunk[Chunk[String]]): Chunk[Chunk[String]] =
-    Chunk.fromIterable(report.groupMap(thm => thm.take(2))(thm => thm.drop(2)).map { case (th, m) =>
-      th.appendedAll(m.flatten)
+    Chunk.fromIterable(report.groupBy(thm => thm.take(2)).map { case (th, thmChunk) =>
+      th ++ thmChunk.map(_.drop(2)).flatten
     })
 }

--- a/core/src/main/scala/zio/metrics/connectors/prometheus/package.scala
+++ b/core/src/main/scala/zio/metrics/connectors/prometheus/package.scala
@@ -25,13 +25,12 @@ package object prometheus {
                               ZIO.succeed(Chunk.empty)
                             }
                           }
-        groupedReport <- ZIO.succeed(groupMetricByType(reportComplete))
+        groupedReport  <- ZIO.succeed(groupMetricByType(reportComplete))
         _              <- clt.set(groupedReport.flatten.addString(new StringBuilder(old.length), "\n").toString())
       } yield ()
 
-  def groupMetricByType(report: Chunk[Chunk[String]]): Chunk[Chunk[String]] = {
-    Chunk.fromIterable(report.groupMap(thm => thm.take(2))(thm => thm.drop(2)).map {
-      case (th, m) => th.appendedAll(m.flatten)
+  def groupMetricByType(report: Chunk[Chunk[String]]): Chunk[Chunk[String]] =
+    Chunk.fromIterable(report.groupMap(thm => thm.take(2))(thm => thm.drop(2)).map { case (th, m) =>
+      th.appendedAll(m.flatten)
     })
-  }
 }

--- a/core/src/test/scala/zio/metrics/connectors/prometheus/PrometheusEncoderSpec.scala
+++ b/core/src/test/scala/zio/metrics/connectors/prometheus/PrometheusEncoderSpec.scala
@@ -9,7 +9,7 @@ import zio.test.TestAspect._
 
 object PrometheusEncoderSpec extends ZIOSpecDefault with Generators {
 
-  override def spec = suite("The Prometheus encoding should")(
+  override def spec = testGroupMetricByType + suite("The Prometheus encoding should")(
     encodeCounter,
     encodeGauge,
     encodeFrequency,
@@ -17,6 +17,46 @@ object PrometheusEncoderSpec extends ZIOSpecDefault with Generators {
     encodeHistogram,
   ) @@ timed @@ timeoutWarning(60.seconds) @@ parallel @@ withLiveClock
 
+  def testGroupMetricByType = suite("The groupMetricByType method should")(
+    test("group metrics of same type together") {
+      val encodedMetric = Chunk(
+        Chunk(
+          "# TYPE jvm_memory_pool_collection_max_bytes gauge",
+          "#HELP jvm_memory_pool_collection_max_bytes",
+          "jvm_memory_pool_collection_max_bytes{pool=\"Metaspace\",} 0.0 1681853772729",
+        ),
+        Chunk(
+          "# TYPE jvm_memory_pool_collection_max_bytes gauge",
+          "#HELP jvm_memory_pool_collection_max_bytes",
+          "jvm_memory_pool_collection_max_bytes{pool=\"G1 Eden Space\",} -1.0 1681853772729"
+        )
+      )
+      val groupedMetric = Chunk(
+        Chunk(
+          "# TYPE jvm_memory_pool_collection_max_bytes gauge",
+          "#HELP jvm_memory_pool_collection_max_bytes",
+          "jvm_memory_pool_collection_max_bytes{pool=\"Metaspace\",} 0.0 1681853772729",
+          "jvm_memory_pool_collection_max_bytes{pool=\"G1 Eden Space\",} -1.0 1681853772729"
+        )
+      )
+      assertTrue(groupMetricByType(encodedMetric) == groupedMetric)
+    },
+    test("not group metrics of different types") {
+      val encodedMetric = Chunk(
+        Chunk(
+          "# TYPE jvm_memory_pool_collection_used_bytes gauge",
+          "#HELP jvm_memory_pool_collection_used_bytes",
+          "TYPE jvm_memory_pool_collection_used_bytes{pool=\"Metaspace\",} 0.0 1681853772729",
+        ),
+        Chunk(
+          "# TYPE jvm_memory_pool_collection_max_bytes gauge",
+          "#HELP jvm_memory_pool_collection_max_bytes",
+          "jvm_memory_pool_collection_max_bytes{pool=\"G1 Eden Space\",} -1.0 1681853772729"
+        )
+      )
+      assertTrue(groupMetricByType(encodedMetric) == encodedMetric)
+    }
+  )
   private def helpString(key: MetricKey.Untyped) =
     key.tags.find(_.key == descriptionKey).fold("")(d => s" ${d.value}")
 

--- a/core/src/test/scala/zio/metrics/connectors/prometheus/PrometheusEncoderSpec.scala
+++ b/core/src/test/scala/zio/metrics/connectors/prometheus/PrometheusEncoderSpec.scala
@@ -9,13 +9,15 @@ import zio.test.TestAspect._
 
 object PrometheusEncoderSpec extends ZIOSpecDefault with Generators {
 
-  override def spec = testGroupMetricByType + suite("The Prometheus encoding should")(
-    encodeCounter,
-    encodeGauge,
-    encodeFrequency,
-    encodeSummary,
-    encodeHistogram,
-  ) @@ timed @@ timeoutWarning(60.seconds) @@ parallel @@ withLiveClock
+  override def spec =
+    testGroupMetricByType +
+      suite("The Prometheus encoding should")(
+        encodeCounter,
+        encodeGauge,
+        encodeFrequency,
+        encodeSummary,
+        encodeHistogram,
+      ) @@ timed @@ timeoutWarning(60.seconds) @@ parallel @@ withLiveClock
 
   def testGroupMetricByType = suite("The groupMetricByType method should")(
     test("group metrics of same type together") {
@@ -28,16 +30,16 @@ object PrometheusEncoderSpec extends ZIOSpecDefault with Generators {
         Chunk(
           "# TYPE jvm_memory_pool_collection_max_bytes gauge",
           "#HELP jvm_memory_pool_collection_max_bytes",
-          "jvm_memory_pool_collection_max_bytes{pool=\"G1 Eden Space\",} -1.0 1681853772729"
-        )
+          "jvm_memory_pool_collection_max_bytes{pool=\"G1 Eden Space\",} -1.0 1681853772729",
+        ),
       )
       val groupedMetric = Chunk(
         Chunk(
           "# TYPE jvm_memory_pool_collection_max_bytes gauge",
           "#HELP jvm_memory_pool_collection_max_bytes",
           "jvm_memory_pool_collection_max_bytes{pool=\"Metaspace\",} 0.0 1681853772729",
-          "jvm_memory_pool_collection_max_bytes{pool=\"G1 Eden Space\",} -1.0 1681853772729"
-        )
+          "jvm_memory_pool_collection_max_bytes{pool=\"G1 Eden Space\",} -1.0 1681853772729",
+        ),
       )
       assertTrue(groupMetricByType(encodedMetric) == groupedMetric)
     },
@@ -51,12 +53,13 @@ object PrometheusEncoderSpec extends ZIOSpecDefault with Generators {
         Chunk(
           "# TYPE jvm_memory_pool_collection_max_bytes gauge",
           "#HELP jvm_memory_pool_collection_max_bytes",
-          "jvm_memory_pool_collection_max_bytes{pool=\"G1 Eden Space\",} -1.0 1681853772729"
-        )
+          "jvm_memory_pool_collection_max_bytes{pool=\"G1 Eden Space\",} -1.0 1681853772729",
+        ),
       )
       assertTrue(groupMetricByType(encodedMetric) == encodedMetric)
-    }
+    },
   )
+
   private def helpString(key: MetricKey.Untyped) =
     key.tags.find(_.key == descriptionKey).fold("")(d => s" ${d.value}")
 

--- a/core/src/test/scala/zio/metrics/connectors/prometheus/PrometheusEncoderSpec.scala
+++ b/core/src/test/scala/zio/metrics/connectors/prometheus/PrometheusEncoderSpec.scala
@@ -46,14 +46,14 @@ object PrometheusEncoderSpec extends ZIOSpecDefault with Generators {
     test("not group metrics of different types") {
       val encodedMetric = Chunk(
         Chunk(
-          "# TYPE jvm_memory_pool_collection_used_bytes gauge",
-          "#HELP jvm_memory_pool_collection_used_bytes",
-          "TYPE jvm_memory_pool_collection_used_bytes{pool=\"Metaspace\",} 0.0 1681853772729",
-        ),
-        Chunk(
           "# TYPE jvm_memory_pool_collection_max_bytes gauge",
           "#HELP jvm_memory_pool_collection_max_bytes",
           "jvm_memory_pool_collection_max_bytes{pool=\"G1 Eden Space\",} -1.0 1681853772729",
+        ),
+        Chunk(
+          "# TYPE jvm_memory_pool_collection_used_bytes gauge",
+          "#HELP jvm_memory_pool_collection_used_bytes",
+          "TYPE jvm_memory_pool_collection_used_bytes{pool=\"Metaspace\",} 0.0 1681853772729",
         ),
       )
       assertTrue(groupMetricByType(encodedMetric) == encodedMetric)


### PR DESCRIPTION
Closes #34 

TLDR: PrometheusEncoder produces JVM metrics that violate Prometheus's specified exposition format. Furthermore, it produces parsing errors when linked with telegraf. The solution is to group all the metrics of the same type together so that there is exactly ONE `TYPE` and `HELP` line in order to adhere to Prometheus's specified exposition format.

#### Problem
Under the [Prometheus Exposition Formats](https://prometheus.io/docs/instrumenting/exposition_formats/#comments-help-text-and-type-information), "Only one HELP line and only one TYPE line may exist for any given metric name" and "The TYPE line for a metric name must appear before the first sample is reported for that metric name". The current implementation violates this specification, and downstream metric collecting agents such as Telegraf depend on this specification to parse metrics, which is currently failing with parsing errors. There are plenty of reproducable violating examples if we include [`DefaultJvmMetrics`](https://github.com/zio/zio/blob/series/2.x/core/jvm/src/main/scala/zio/metrics/jvm/DefaultJvmMetrics.scala) to our metrics.

#### Solution
We need to group together the metrics that have the same TYPE line but may have different labels. For each group of metrics with the same TYPE, we need one `TYPE` line, followed by one `HELP` line, followed by the numerous metrics of the given type. 

As an example, prior to this change, the output of DefaultJvmMetrics encoded the jvm memory committed bytes as:
```
# TYPE jvm_memory_bytes_committed gauge
# HELP jvm_memory_bytes_committed
jvm_memory_bytes_committed{area="heap",} 1.073741824E9 1681853772729
...
... other metrics
...
# TYPE jvm_memory_bytes_committed gauge
# HELP jvm_memory_bytes_committed
jvm_memory_bytes_committed{area="nonheap",} 3.06315264E8 1681853772729
```
This violates the Prometheus specification as described above.

With the changes in this pull request, the output looks like:
```
# TYPE jvm_memory_bytes_committed gauge
# HELP jvm_memory_bytes_committed
jvm_memory_bytes_committed{area="heap",} 1.073741824E9 1681853772729
jvm_memory_bytes_committed{area="nonheap",} 3.06315264E8 1681853772729
```

 #### Suggested improvements
I noticed that I am introducing some magic numbers (`thm.take(2)`) coming out of the assumption that each Chunk of String encoded will start with TYPE and HELP strings. To make the code more readable, we could introduce two case classes, 
`case class EncodedHead(typeComment: String, helpComment: String)`
`case class EncodedMetric(encodedHead: EncodedHead, metrics: Chunk[String])`
and change the `PrometheusEncoder.encode(..)` method to return `EncodedMetric` instead of `Chunk[String]`. 
This will allow us to make the `groupMetricByType` method cleaner to read:
```
  def groupMetricByType(report: Chunk[EncodedMetric]): Chunk[Chunk[String]] = {
    Chunk.fromIterable(report.groupMap(thm => thm.encodedHead)(thm => thm.metrics).map {
      case (EncodedHead(t, h), m) => Chunk(t, h) ++ m.flatten
    })
  }
```
However, I am unsure about the performance tradeoffs with creating instances of the two introduced classes for each metric, so I am leaving it as a suggestion. I'd be happy to include it in if deemed viable.