### PR TITLE
Integration with Micrometer for greater ZIO monitoring capabilities

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ addCommandAlias("fmt", "all scalafmtSbt scalafmt test:scalafmt")
 addCommandAlias("check", "all scalafmtSbtCheck scalafmtCheck test:scalafmtCheck")
 
 lazy val root =
-  project.in(file(".")).settings(publish / skip := true).aggregate(core, docs)
+  project.in(file(".")).settings(publish / skip := true).aggregate(core, micrometer, docs)
 
 lazy val core =
   project
@@ -56,12 +56,27 @@ lazy val core =
         "dev.zio" %%% "zio-json"     % Version.zioJson,
         "dev.zio" %%% "zio-streams"  % Version.zio,
         "dev.zio"  %% "zio-http"     % Version.zioHttp,
+        "dev.zio"  %% "zio-http"     % Version.zioHttp,
         "dev.zio" %%% "zio-test"     % Version.zio % Test,
         "dev.zio" %%% "zio-test-sbt" % Version.zio % Test,
       ),
     )
     .settings(buildInfoSettings("zio.metrics.connectors"))
     .enablePlugins(BuildInfoPlugin)
+
+lazy val micrometer =
+  project
+    .in(file("micrometer"))
+    .settings(
+      stdSettings("zio.metrics.connectors.micrometer"),
+      libraryDependencies ++= Seq(
+        "io.micrometer" % "micrometer-core"                % Version.micrometer,
+        "io.micrometer" % "micrometer-registry-prometheus" % Version.micrometer % Test,
+      ),
+    )
+    .settings(buildInfoSettings("zio.metrics.connectors.micrometer"))
+    .enablePlugins(BuildInfoPlugin)
+    .dependsOn(core % "compile->compile;test->test")
 
 lazy val docs = project
   .in(file("zio-metrics-connectors-docs"))

--- a/core/src/main/scala/zio/metrics/connectors/datadog/DataDogListener.scala
+++ b/core/src/main/scala/zio/metrics/connectors/datadog/DataDogListener.scala
@@ -3,6 +3,7 @@ package zio.metrics.connectors.datadog
 import zio.Unsafe
 import zio.internal.RingBuffer
 import zio.metrics.{MetricKey, MetricKeyType, MetricListener}
+import zio.metrics.MetricKeyType.Gauge
 
 class DataDogListener(queue: RingBuffer[(MetricKey[MetricKeyType.Histogram], Double)]) extends MetricListener {
   def updateHistogram(key: MetricKey[MetricKeyType.Histogram], value: Double)(implicit unsafe: Unsafe): Unit = {
@@ -10,6 +11,8 @@ class DataDogListener(queue: RingBuffer[(MetricKey[MetricKeyType.Histogram], Dou
   }
 
   def updateGauge(key: MetricKey[MetricKeyType.Gauge], value: Double)(implicit unsafe: Unsafe): Unit = ()
+
+  def modifyGauge(key: MetricKey[Gauge], value: Double)(implicit unsafe: Unsafe): Unit = ()
 
   def updateFrequency(key: MetricKey[MetricKeyType.Frequency], value: String)(implicit unsafe: Unsafe): Unit = ()
 
@@ -21,4 +24,5 @@ class DataDogListener(queue: RingBuffer[(MetricKey[MetricKeyType.Histogram], Dou
   ): Unit = ()
 
   def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double)(implicit unsafe: Unsafe): Unit = ()
+
 }

--- a/core/src/main/scala/zio/metrics/connectors/newrelic/package.scala
+++ b/core/src/main/scala/zio/metrics/connectors/newrelic/package.scala
@@ -6,12 +6,14 @@ import zio.metrics.connectors.internal.MetricsClient
 
 package object newrelic {
 
-  lazy val newRelicLayer: ZLayer[MetricsConfig & NewRelicConfig, Nothing, Unit] =
-    ZLayer.makeSome[MetricsConfig & NewRelicConfig, Unit](
-      make,
-      Client.default.orDie,
-      Scope.default,
-    )
+  lazy val newRelicLayer: ZLayer[MetricsConfig & NewRelicConfig, Nothing, Unit] = {
+    val metricsConfig  = ZLayer.service[MetricsConfig]
+    val newRelicConfig = ZLayer.service[NewRelicConfig]
+    val client         = Client.default.orDie
+    val scope          = Scope.default
+
+    metricsConfig ++ newRelicConfig ++ (scope >>> client) >>> make
+  }
 
   private lazy val make: URLayer[MetricsConfig & NewRelicConfig & Client, Unit] = ZLayer(for {
     encoder <- newRelicEncoder

--- a/core/src/test/scala/zio/metrics/connectors/Generators.scala
+++ b/core/src/test/scala/zio/metrics/connectors/Generators.scala
@@ -118,13 +118,11 @@ trait Generators {
 
   def unqiueNonEmptyString(ref: Ref[Set[String]]) =
     Gen(
-      nonEmptyString.sample.filterZIO {
-        case Some(s) =>
-          for {
-            exists <- ref.get.map(_.contains(s.value))
-            _      <- if (!exists) ref.update(_ + s.value) else ZIO.unit
-          } yield !exists
-        case _       => ZIO.succeed(true)
+      nonEmptyString.sample.filterZIO { s =>
+        for {
+          exists <- ref.get.map(_.contains(s.value))
+          _      <- if (!exists) ref.update(_ + s.value) else ZIO.unit
+        } yield !exists
       },
     )
 

--- a/docs/metrics/micrometer-connector.md
+++ b/docs/metrics/micrometer-connector.md
@@ -1,0 +1,93 @@
+---
+id: micrometer-connector
+title: Micrometer Connector
+---
+
+ZIO ZMX also has an integration with [Micrometer](https://micrometer.io/), a powerful metrics instrumentation library.
+By combining these two
+frameworks, developers can benefit
+from comprehensive and flexible metrics monitoring capabilities within their ZIO applications. This integration allows
+for efficient monitoring, gathering, and reporting of key performance indicators (KPIs) and other metrics for enhanced
+observability.
+
+## Benefits
+
+Micrometer integration offers a range of benefits that make it an excellent choice for integrating with ZIO Metrics.
+Here are some key advantages:
+
+### 1. Comprehensive Metrics Support
+
+Micrometer provides a vendor-neutral facade for various monitoring systems, including Prometheus, Datadog, Graphite,
+and more. The same like slf4j for logs but for observability. It offers a unified API for recording metrics, allowing
+developers to easily integrate with multiple backend systems and switch between different monitoring systems without
+major code changes for its ZIO applications. You can choose whatever you want as monitoring tool - Grafana,
+Prometheus, and Jaeger and so on.
+
+### 2. Real-time Metrics Updates
+
+By leveraging the low-level integration with the ZMX Metrics core client listener, the module provides immediate
+updates to Micrometer whenever metric changes occur within the ZIO application. This real-time synchronization
+ensures that the metrics reported by Micrometer accurately reflect the current state of the application, enabling
+timely monitoring and analysis.
+
+### 3. Always on trend of standards
+
+Integration with Micrometer ensures that developers are always on trend of standards with metrics format changes and
+can take advantage of the latest updates and improvements in the monitoring ecosystem. By relying on Micrometer as
+the integration layer, developers gain compatibility with the latest monitoring systems, future-proof their
+monitoring infrastructure, benefit from community-driven updates and support, and simplify maintenance and upgrades.
+This integration provides a reliable and scalable solution for metrics monitoring in ZIO-based applications, allowing
+developers to focus on their core business logic while staying at the forefront of monitoring technology.
+
+## Example of usage
+
+1. Import Dependencies
+
+   In your project's build configuration, add the following dependency to import the ZIO Metrics Micrometer module:
+
+```
+   libraryDependencies += "dev.zio" %%% "zio-metrics-micrometer" % latest
+```
+
+2. Choose Micrometer Backend
+
+   Decide on the backend for the Micrometer registry. You can use the built-in
+   'SimpleMeterRegistry', which stores all metrics in memory (commonly used for testing), or select another backend for
+   external integration. In this example, we'll use Prometheus as the backend.
+
+```
+   "io.micrometer" % "micrometer-registry-prometheus" % latest
+```
+
+3. Provide Micrometer and its backend Layer to your main ZIO effect
+
+   `zio-metrics-micrometer` gives you `micrometer.micrometerLayer` which initializes a bridge between ZMX and
+   Micrometer.
+   You should also provide a layer with a backend for micrometer.
+
+4. Optionally enable Core ZIO Metrics and Default JVM Metrics
+
+   Enable core ZIO Metrics by providing `Runtime.enableRuntimeMetrics` to your main application's ZIO effect. This
+   ensures that basic ZIO metrics, such as fiber counts and execution times, are collected. Additionally, include
+   `DefaultJvmMetrics.live` in your layer composition to enable default JVM metrics collection.
+
+Here's an example of how example may look like:
+
+```scala
+
+object SampleApp extends ZIOAppDefault {
+
+  def program[R, E, T]: ZIO[R, E, T] = ???
+
+  override def run: ZIO[Environment & ZIOAppArgs & Scope, Any, Any] = (for {
+    _ <- program
+  } yield ())
+    .provide(
+      micrometer.micrometerLayer,
+      ZLayer.succeed(new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)),
+      Runtime.enableRuntimeMetrics,
+      DefaultJvmMetrics.live.unit,
+    )
+}
+
+```

--- a/docs/metrics/micrometer-connector.md
+++ b/docs/metrics/micrometer-connector.md
@@ -3,12 +3,10 @@ id: micrometer-connector
 title: Micrometer Connector
 ---
 
-ZIO ZMX also has an integration with [Micrometer](https://micrometer.io/), a powerful metrics instrumentation library.
-By combining these two
-frameworks, developers can benefit
-from comprehensive and flexible metrics monitoring capabilities within their ZIO applications. This integration allows
-for efficient monitoring, gathering, and reporting of key performance indicators (KPIs) and other metrics for enhanced
-observability.
+ZIO Metrics has an integration with [Micrometer](https://micrometer.io/), a powerful metrics instrumentation library.
+By combining these two frameworks, developers can benefit from comprehensive and flexible metrics monitoring capabilities
+within their ZIO applications. This integration allows for efficient monitoring, gathering, and reporting of key
+performance indicators (KPIs) and other metrics for enhanced observability.
 
 ## Benefits
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -11,6 +11,7 @@ const sidebars = {
         "metrics/zmx-metric-reference",
         "metrics/statsd-client",
         "metrics/prometheus-client",
+        "metrics/micrometer-connector",
         "metrics/instrumentation-examples",
       ]
     }

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicroMeterConfig.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicroMeterConfig.scala
@@ -1,6 +1,0 @@
-package zio.metrics.connectors.micrometer
-
-final case class MicroMeterConfig(summaryPercentileDigitsOfPrecision: Int)
-object MicroMeterConfig {
-  val default: MicroMeterConfig = MicroMeterConfig(3)
-}

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicroMeterConfig.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicroMeterConfig.scala
@@ -1,0 +1,6 @@
+package zio.metrics.connectors.micrometer
+
+final case class MicroMeterConfig(summaryPercentileDigitsOfPrecision: Int)
+object MicroMeterConfig {
+  val default: MicroMeterConfig = MicroMeterConfig(3)
+}

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerConfig.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerConfig.scala
@@ -1,0 +1,6 @@
+package zio.metrics.connectors.micrometer
+
+final case class MicrometerConfig(summaryPercentileDigitsOfPrecision: Int)
+object MicrometerConfig {
+  val default: MicrometerConfig = MicrometerConfig(summaryPercentileDigitsOfPrecision = 3)
+}

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
@@ -13,9 +13,9 @@ import zio.metrics.connectors.micrometer.internal.AtomicDouble
 import io.micrometer.core.instrument.{DistributionSummary, MeterRegistry, Tag}
 
 private[micrometer] class MicrometerMetricListener(
-                                                    meterRegistry: MeterRegistry,
-                                                    config: MicrometerConfig,
-                                                    activeGauges: ConcurrentMap[MetricKey.Gauge, AtomicDouble])
+  meterRegistry: MeterRegistry,
+  config: MicrometerConfig,
+  activeGauges: ConcurrentMap[MetricKey.Gauge, AtomicDouble])
     extends MetricListener {
   private def getOrCreateGaugeRef(key: MetricKey[Gauge]): AtomicDouble =
     activeGauges.computeIfAbsent(

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
@@ -1,34 +1,33 @@
 package zio.metrics.connectors.micrometer
 
-import java.lang.{Double => JDouble}
 import java.time.Instant
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
 
-import scala.jdk.CollectionConverters.IterableHasAsJava
+import scala.jdk.CollectionConverters._
 
-import zio.{Unsafe, ZIO}
+import zio.{Unsafe, URIO, ZIO}
 import zio.metrics.{MetricKey, MetricKeyType, MetricListener}
 import zio.metrics.MetricKeyType.{Counter, Frequency, Gauge}
+import zio.metrics.connectors.micrometer.internal.AtomicDouble
 
 import io.micrometer.core.instrument.{DistributionSummary, MeterRegistry, Tag}
 
-private[micrometer] class MicrometerMetricListener(meterRegistry: MeterRegistry) extends MetricListener {
-  private lazy val gauges: ConcurrentHashMap[MetricKey[Gauge], AtomicDouble] =
-    new ConcurrentHashMap[MetricKey[Gauge], AtomicDouble]()
-
+private[micrometer] class MicrometerMetricListener(
+  meterRegistry: MeterRegistry,
+  config: MicroMeterConfig,
+  activeGauges: ConcurrentMap[MetricKey.Gauge, AtomicDouble])
+    extends MetricListener {
   private def getOrCreateGaugeRef(key: MetricKey[Gauge]): AtomicDouble =
-    gauges
-      .computeIfAbsent(
-        key,
-        _ =>
-          meterRegistry.gauge(
-            key.name,
-            micrometerTags(key.tags).asJava,
-            AtomicDouble.make(0),
-            (v: AtomicDouble) => v.get(),
-          ),
-      )
+    activeGauges.computeIfAbsent(
+      key,
+      _ =>
+        meterRegistry.gauge(
+          key.name,
+          micrometerTags(key.tags).asJava,
+          AtomicDouble.make(0),
+          (v: AtomicDouble) => v.get(),
+        ),
+    )
 
   override def updateHistogram(
     key: MetricKey[MetricKeyType.Histogram],
@@ -70,7 +69,7 @@ private[micrometer] class MicrometerMetricListener(meterRegistry: MeterRegistry)
       .distributionStatisticBufferLength(key.keyType.maxSize)
       .distributionStatisticExpiry(key.keyType.maxAge)
       .publishPercentiles(key.keyType.quantiles: _*)
-      .percentilePrecision(3) // should this be added to config?
+      .percentilePrecision(config.summaryPercentileDigitsOfPrecision)
       .register(meterRegistry)
       .record(value)
 
@@ -78,52 +77,13 @@ private[micrometer] class MicrometerMetricListener(meterRegistry: MeterRegistry)
     meterRegistry
       .counter(key.name, micrometerTags(key.tags).asJava)
       .increment(value)
-
-  /**
-   * Scala's `Double` implementation does not play nicely with Java's
-   * `AtomicReference.compareAndSwap` as `compareAndSwap` uses Java's `==`
-   * reference equality when it performs an equality check. This means that even
-   * if two Scala `Double`s have the same value, they will still fail
-   * `compareAndSwap` as they will most likely be two, distinct object
-   * references. Thus, `compareAndSwap` will fail.
-   *
-   * This `AtomicDouble` implementation is a workaround for this issue that is
-   * backed by an `AtomicLong` instead of an `AtomicReference` in which the
-   * Double's bits are stored as a Long value. This approach also reduces boxing
-   * and unboxing overhead that can be incurred with `AtomicReference`.
-   */
-  final private class AtomicDouble private (private val ref: AtomicLong) {
-
-    def get(): Double =
-      JDouble.longBitsToDouble(ref.get())
-
-    def set(newValue: Double): Unit =
-      ref.set(JDouble.doubleToLongBits(newValue))
-
-    def compareAndSet(expected: Double, newValue: Double): Boolean =
-      ref.compareAndSet(JDouble.doubleToLongBits(expected), JDouble.doubleToLongBits(newValue))
-
-    def incrementBy(value: Double): Unit = {
-      var loop = true
-
-      while (loop) {
-        val current = get()
-        loop = !compareAndSet(current, current + value)
-      }
-    }
-  }
-
-  private object AtomicDouble {
-
-    def make(value: Double): AtomicDouble =
-      new AtomicDouble(new AtomicLong(JDouble.doubleToLongBits(value)))
-  }
-
 }
 
 object MicrometerMetricListener {
-
-  private[micrometer] def make: ZIO[MeterRegistry, Nothing, MicrometerMetricListener] =
-    ZIO.serviceWith[MeterRegistry](new MicrometerMetricListener(_))
-
+  private[micrometer] def make: URIO[MeterRegistry with MicroMeterConfig, MicrometerMetricListener] =
+    for {
+      meterRegistry <- ZIO.service[MeterRegistry]
+      config        <- ZIO.service[MicroMeterConfig]
+      activeGauges  <- ZIO.succeed(new ConcurrentHashMap[MetricKey.Gauge, AtomicDouble])
+    } yield new MicrometerMetricListener(meterRegistry, config, activeGauges)
 }

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
@@ -13,9 +13,9 @@ import zio.metrics.connectors.micrometer.internal.AtomicDouble
 import io.micrometer.core.instrument.{DistributionSummary, MeterRegistry, Tag}
 
 private[micrometer] class MicrometerMetricListener(
-  meterRegistry: MeterRegistry,
-  config: MicroMeterConfig,
-  activeGauges: ConcurrentMap[MetricKey.Gauge, AtomicDouble])
+                                                    meterRegistry: MeterRegistry,
+                                                    config: MicrometerConfig,
+                                                    activeGauges: ConcurrentMap[MetricKey.Gauge, AtomicDouble])
     extends MetricListener {
   private def getOrCreateGaugeRef(key: MetricKey[Gauge]): AtomicDouble =
     activeGauges.computeIfAbsent(
@@ -80,10 +80,10 @@ private[micrometer] class MicrometerMetricListener(
 }
 
 object MicrometerMetricListener {
-  private[micrometer] def make: URIO[MeterRegistry with MicroMeterConfig, MicrometerMetricListener] =
+  private[micrometer] def make: URIO[MeterRegistry with MicrometerConfig, MicrometerMetricListener] =
     for {
       meterRegistry <- ZIO.service[MeterRegistry]
-      config        <- ZIO.service[MicroMeterConfig]
+      config        <- ZIO.service[MicrometerConfig]
       activeGauges  <- ZIO.succeed(new ConcurrentHashMap[MetricKey.Gauge, AtomicDouble])
     } yield new MicrometerMetricListener(meterRegistry, config, activeGauges)
 }

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
@@ -1,0 +1,113 @@
+package zio.metrics.connectors.micrometer
+
+import java.lang.{Double => JDouble}
+import java.time.Instant
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.jdk.CollectionConverters.IterableHasAsJava
+
+import zio.{Unsafe, ZIO}
+import zio.metrics.{MetricKey, MetricKeyType, MetricListener}
+import zio.metrics.MetricKeyType.{Counter, Frequency, Gauge}
+
+import io.micrometer.core.instrument.{DistributionSummary, MeterRegistry, Tag}
+
+private[micrometer] class MicrometerMetricListener(meterRegistry: MeterRegistry) extends MetricListener {
+  private lazy val gauges: ConcurrentHashMap[MetricKey[Gauge], AtomicDouble] =
+    new ConcurrentHashMap[MetricKey[Gauge], AtomicDouble]()
+
+  override def updateHistogram(
+    key: MetricKey[MetricKeyType.Histogram],
+    value: Double,
+  )(implicit unsafe: Unsafe,
+  ): Unit =
+    DistributionSummary
+      .builder(key.name)
+      .tags(micrometerTags(key.tags).asJava)
+      .serviceLevelObjectives(key.keyType.boundaries.values.filter(_ > 0): _*) // micrometer prohibits <= 0 slo values
+      .register(meterRegistry)
+      .record(value)
+
+  override def updateGauge(key: MetricKey[Gauge], value: Double)(implicit unsafe: Unsafe): Unit =
+    gauges
+      .computeIfAbsent(
+        key,
+        _ =>
+          meterRegistry.gauge(
+            key.name,
+            micrometerTags(key.tags).asJava,
+            AtomicDouble.make(0),
+            (v: AtomicDouble) => v.get(),
+          ),
+      )
+      .set(value)
+
+  override def updateFrequency(key: MetricKey[Frequency], value: String)(implicit unsafe: Unsafe): Unit =
+    meterRegistry
+      .counter(
+        key.name,
+        (micrometerTags(key.tags) ++ Iterable(Tag.of("bucket", value))).asJava,
+      )
+      .increment()
+
+  override def updateSummary(
+    key: MetricKey[MetricKeyType.Summary],
+    value: Double,
+    instant: Instant,
+  )(implicit unsafe: Unsafe,
+  ): Unit =
+    DistributionSummary
+      .builder(key.name)
+      .tags(
+        (micrometerTags(key.tags) ++ Iterable(Tag.of("error", key.keyType.error.toString))).asJava,
+      )
+      .distributionStatisticBufferLength(key.keyType.maxSize)
+      .distributionStatisticExpiry(key.keyType.maxAge)
+      .publishPercentiles(key.keyType.quantiles: _*)
+      .percentilePrecision(3) // should this be added to config?
+      .register(meterRegistry)
+      .record(value)
+
+  override def updateCounter(key: MetricKey[Counter], value: Double)(implicit unsafe: Unsafe): Unit =
+    meterRegistry
+      .counter(key.name, micrometerTags(key.tags).asJava)
+      .increment(value)
+
+  /**
+   * Scala's `Double` implementation does not play nicely with Java's
+   * `AtomicReference.compareAndSwap` as `compareAndSwap` uses Java's `==`
+   * reference equality when it performs an equality check. This means that even
+   * if two Scala `Double`s have the same value, they will still fail
+   * `compareAndSwap` as they will most likely be two, distinct object
+   * references. Thus, `compareAndSwap` will fail.
+   *
+   * This `AtomicDouble` implementation is a workaround for this issue that is
+   * backed by an `AtomicLong` instead of an `AtomicReference` in which the
+   * Double's bits are stored as a Long value. This approach also reduces boxing
+   * and unboxing overhead that can be incurred with `AtomicReference`.
+   */
+  final private class AtomicDouble private (private val ref: AtomicLong) {
+
+    def get(): Double =
+      JDouble.longBitsToDouble(ref.get())
+
+    def set(newValue: Double): Unit =
+      ref.set(JDouble.doubleToLongBits(newValue))
+
+  }
+
+  private object AtomicDouble {
+
+    def make(value: Double): AtomicDouble =
+      new AtomicDouble(new AtomicLong(JDouble.doubleToLongBits(value)))
+  }
+
+}
+
+object MicrometerMetricListener {
+
+  private[micrometer] def make: ZIO[MeterRegistry, Nothing, MicrometerMetricListener] =
+    ZIO.serviceWith[MeterRegistry](new MicrometerMetricListener(_))
+
+}

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/internal/AtomicDouble.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/internal/AtomicDouble.scala
@@ -1,0 +1,42 @@
+package zio.metrics.connectors.micrometer.internal
+
+import java.lang.{Double => JDouble}
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Scala's `Double` implementation does not play nicely with Java's
+ * `AtomicReference.compareAndSwap` as `compareAndSwap` uses Java's `==`
+ * reference equality when it performs an equality check. This means that even
+ * if two Scala `Double`s have the same value, they will still fail
+ * `compareAndSwap` as they will most likely be two, distinct object
+ * references. Thus, `compareAndSwap` will fail.
+ *
+ * This `AtomicDouble` implementation is a workaround for this issue that is
+ * backed by an `AtomicLong` instead of an `AtomicReference` in which the
+ * Double's bits are stored as a Long value. This approach also reduces boxing
+ * and unboxing overhead that can be incurred with `AtomicReference`.
+ */
+final private[micrometer] class AtomicDouble private (private val ref: AtomicLong) extends AnyVal {
+
+  def get(): Double =
+    JDouble.longBitsToDouble(ref.get())
+
+  def set(newValue: Double): Unit =
+    ref.set(JDouble.doubleToLongBits(newValue))
+
+  def compareAndSet(expected: Double, newValue: Double): Boolean =
+    ref.compareAndSet(JDouble.doubleToLongBits(expected), JDouble.doubleToLongBits(newValue))
+
+  def incrementBy(value: Double): Unit = {
+    var loop = true
+
+    while (loop) {
+      val current = get()
+      loop = !compareAndSet(current, current + value)
+    }
+  }
+}
+private[micrometer] object AtomicDouble {
+  def make(value: Double): AtomicDouble =
+    new AtomicDouble(new AtomicLong(JDouble.doubleToLongBits(value)))
+}

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/package.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/package.scala
@@ -1,0 +1,27 @@
+package zio.metrics.connectors
+
+import scala.collection.immutable.Iterable
+
+import zio.{Unsafe, ZIO, ZLayer}
+import zio.metrics.{MetricClient, MetricLabel}
+
+import io.micrometer.core.instrument.{MeterRegistry, Tag}
+
+package object micrometer {
+
+  lazy val micrometerLayer: ZLayer[MeterRegistry, Nothing, Unit] =
+    ZLayer.scoped(
+      for {
+        micrometerMetricListener <- MicrometerMetricListener.make
+        _                        <- Unsafe.unsafe(implicit unsafe =>
+                                      ZIO.acquireRelease(ZIO.succeed(MetricClient.addListener(micrometerMetricListener)))(_ =>
+                                        ZIO.succeed(MetricClient.removeListener(micrometerMetricListener)),
+                                      ),
+                                    )
+      } yield (),
+    )
+
+  private[micrometer] def micrometerTags(zioMetricTags: Iterable[MetricLabel]): Iterable[Tag] =
+    zioMetricTags.map(metricTag => Tag.of(metricTag.key, metricTag.value))
+
+}

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/package.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/package.scala
@@ -9,7 +9,7 @@ import io.micrometer.core.instrument.{MeterRegistry, Tag}
 
 package object micrometer {
 
-  val micrometerLayer: ZLayer[MeterRegistry with MicroMeterConfig, Nothing, Unit] =
+  lazy val micrometerLayer: ZLayer[MeterRegistry with MicrometerConfig, Nothing, Unit] =
     ZLayer.scoped(
       for {
         micrometerMetricListener <- MicrometerMetricListener.make

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/package.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/package.scala
@@ -9,7 +9,7 @@ import io.micrometer.core.instrument.{MeterRegistry, Tag}
 
 package object micrometer {
 
-  lazy val micrometerLayer: ZLayer[MeterRegistry, Nothing, Unit] =
+  val micrometerLayer: ZLayer[MeterRegistry with MicroMeterConfig, Nothing, Unit] =
     ZLayer.scoped(
       for {
         micrometerMetricListener <- MicrometerMetricListener.make
@@ -23,5 +23,4 @@ package object micrometer {
 
   private[micrometer] def micrometerTags(zioMetricTags: Iterable[MetricLabel]): Iterable[Tag] =
     zioMetricTags.map(metricTag => Tag.of(metricTag.key, metricTag.value))
-
 }

--- a/micrometer/src/test/scala/sample/SampleApp.scala
+++ b/micrometer/src/test/scala/sample/SampleApp.scala
@@ -7,7 +7,7 @@ import zio.http._
 import zio.http.html._
 import zio.http.model.{Headers, Method}
 import zio.metrics.connectors.micrometer
-import zio.metrics.connectors.micrometer.MicroMeterConfig
+import zio.metrics.connectors.micrometer.MicrometerConfig
 import zio.metrics.jvm.DefaultJvmMetrics
 import zio.sample.InstrumentedSample
 
@@ -55,7 +55,7 @@ object SampleApp extends ZIOAppDefault with InstrumentedSample {
       serverConfig,
       Server.live,
       ZLayer.succeed(new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)),
-      ZLayer.succeed(MicroMeterConfig.default),
+      ZLayer.succeed(MicrometerConfig.default),
       micrometer.micrometerLayer,
       Runtime.enableRuntimeMetrics,
       DefaultJvmMetrics.live.unit,

--- a/micrometer/src/test/scala/sample/SampleApp.scala
+++ b/micrometer/src/test/scala/sample/SampleApp.scala
@@ -1,0 +1,61 @@
+package sample
+
+import java.net.InetSocketAddress
+
+import zio._
+import zio.http._
+import zio.http.html._
+import zio.http.model.{Headers, Method}
+import zio.metrics.connectors.micrometer
+import zio.metrics.jvm.DefaultJvmMetrics
+import zio.sample.InstrumentedSample
+
+import io.micrometer.prometheus.{PrometheusConfig, PrometheusMeterRegistry}
+
+object SampleApp extends ZIOAppDefault with InstrumentedSample {
+
+  private val bindPort = 8080
+  private val nThreads = 5
+
+  private lazy val indexPage =
+    """<html>
+      |<title>Simple Server</title>
+      |<body>
+      |<p><a href="/micrometer/prometheusMetrics">Prometheus Metrics</a></p>
+      |</body
+      |</html>""".stripMargin
+
+  private lazy val static =
+    Http.collect[Request] { case Method.GET -> !! => Response.html(Html.fromString(indexPage)) }
+
+  private lazy val micrometerPrometheusRouter =
+    Http
+      .collectZIO[Request] { case Method.GET -> !! / "micrometer" / "prometheusMetrics" =>
+        ZIO.serviceWith[PrometheusMeterRegistry](m => noCors(Response.text(m.scrape())))
+      }
+
+  private def noCors(r: Response): Response =
+    r.updateHeaders(_.combine(Headers(("Access-Control-Allow-Origin", "*"))))
+
+  private val serverInstall =
+    Server.install(static ++ micrometerPrometheusRouter)
+
+  private lazy val runHttp = (serverInstall *> ZIO.never).forkDaemon
+
+  private lazy val serverConfig =
+    ZLayer.succeed(ServerConfig(address = new InetSocketAddress(bindPort), nThreads = nThreads))
+
+  override def run: ZIO[Environment & ZIOAppArgs & Scope, Any, Any] = (for {
+    f <- runHttp
+    _ <- program
+    _ <- f.join
+  } yield ())
+    .provide(
+      serverConfig,
+      Server.live,
+      ZLayer.succeed(new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)),
+      micrometer.micrometerLayer,
+      Runtime.enableRuntimeMetrics,
+      DefaultJvmMetrics.live.unit,
+    )
+}

--- a/micrometer/src/test/scala/sample/SampleApp.scala
+++ b/micrometer/src/test/scala/sample/SampleApp.scala
@@ -7,6 +7,7 @@ import zio.http._
 import zio.http.html._
 import zio.http.model.{Headers, Method}
 import zio.metrics.connectors.micrometer
+import zio.metrics.connectors.micrometer.MicroMeterConfig
 import zio.metrics.jvm.DefaultJvmMetrics
 import zio.sample.InstrumentedSample
 
@@ -54,6 +55,7 @@ object SampleApp extends ZIOAppDefault with InstrumentedSample {
       serverConfig,
       Server.live,
       ZLayer.succeed(new PrometheusMeterRegistry(PrometheusConfig.DEFAULT)),
+      ZLayer.succeed(MicroMeterConfig.default),
       micrometer.micrometerLayer,
       Runtime.enableRuntimeMetrics,
       DefaultJvmMetrics.live.unit,

--- a/micrometer/src/test/scala/zio/metrics/connectors/micrometer/MicrometerMetricsSpec.scala
+++ b/micrometer/src/test/scala/zio/metrics/connectors/micrometer/MicrometerMetricsSpec.scala
@@ -1,0 +1,116 @@
+package zio.metrics.connectors.micrometer
+
+import java.time.Instant
+
+import scala.jdk.CollectionConverters.{CollectionHasAsScala, IterableHasAsJava}
+
+import zio.{durationInt, Chunk, ZIO, ZLayer}
+import zio.metrics.{Metric, MetricKey, MetricKeyType}
+import zio.test.{assertTrue, ZIOSpecDefault}
+import zio.test.TestAspect.{timed, timeoutWarning}
+
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.distribution.CountAtBucket
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+
+object MicrometerMetricsSpec extends ZIOSpecDefault {
+
+  override def spec = suite("The Micrometer registry should")(
+    testCounter,
+    testGauge,
+    testHistogram,
+    testSummary,
+    testFrequency,
+  ).provide(
+    micrometerLayer,
+    ZLayer.succeed(new SimpleMeterRegistry()),
+  ) @@ timed @@ timeoutWarning(60.seconds)
+
+  private def testMetric[Type <: MetricKeyType](
+    key: MetricKey[Type],
+  )(testValues: Seq[key.keyType.In],
+  ) =
+    for {
+      meterRegistry <- ZIO.service[MeterRegistry]
+      _             <- ZIO.foreach(testValues)(v => ZIO.succeed(v) @@ Metric.fromMetricKey(key).tagged("key", "value"))
+    } yield meterRegistry.get(key.name).tags(micrometerTags(key.tags).asJava)
+
+  private val testCounter = test("catch zio counter updates") {
+    val name     = "testCounter"
+    val testData = Seq(0.5, 5.0)
+    testMetric(MetricKey.counter(name))(testData).map(searchResult =>
+      assertTrue(searchResult.counter().count() == testData.sum),
+    )
+  }
+
+  private val testGauge = test("catch zio gauge updates") {
+    val name     = "testGauge"
+    val testData = Seq(0.5, 5.0)
+    testMetric(MetricKey.gauge(name))(testData).map(searchResult =>
+      assertTrue(searchResult.gauge().value() == testData.last),
+    )
+  }
+
+  private val testHistogram = test("catch zio histogram updates") {
+    val name     = "testHistogram"
+    val testData = Seq(0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5)
+    val buckets  = MetricKeyType.Histogram.Boundaries.linear(1, 1, 3)
+
+    testMetric(MetricKey.histogram(name, buckets))(testData).map(searchResult =>
+      assertTrue {
+        val resultSummary = searchResult.summary().takeSnapshot()
+        resultSummary.count() == testData.size &&
+        resultSummary.total() == testData.sum &&
+        resultSummary.max() == testData.max &&
+        resultSummary.histogramCounts().toSeq == buckets.values.map(bound =>
+          new CountAtBucket(bound, testData.count(_ <= bound)),
+        )
+      },
+    )
+  }
+
+  private val testSummary = test("catch zio summary updates") {
+    val name        = "testSummary"
+    val now         = Instant.now()
+    val testData    = Chunk.from(1 to 1000).map(i => i.toDouble -> now)
+    val percentiles = Chunk(0.1, 0.5, 0.9)
+    testMetric(MetricKey.summary(name, 1.day, 100, 0.03d, percentiles))(testData).map(searchResult =>
+      assertTrue {
+        val resultSummary = searchResult.summary().takeSnapshot()
+        resultSummary.count() == testData.size &&
+        resultSummary.total() == testData.map(_._1).sum &&
+        resultSummary.max() == testData.map(_._1).max &&
+        resultSummary
+          .percentileValues()
+          .toSeq
+          /* Under the covers, Micrometer uses HdrHistogram to compute percentiles.
+          HdrHistogram gives us the opportunity tradeoff computational complexity for accuracy.
+          Depends on Percentile precision final percentile value may changed.
+          For check purpose we may just round value to Int.
+           */
+          .map(pv => pv.percentile() -> pv.value().toInt) ==
+          Seq(
+            0.1 -> 100,
+            0.5 -> 500,
+            0.9 -> 900,
+          )
+      },
+    )
+  }
+
+  private val testFrequency = test("catch zio frequency updates") {
+    val name     = "testFrequency"
+    val testData = Seq("Sample1", "Sample2", "Sample1", "Sample1")
+
+    def checkBucketCounter(counters: Iterable[io.micrometer.core.instrument.Counter], value: String): Boolean =
+      counters
+        .find(_.getId.getTags.asScala.exists(tag => tag.getKey == "bucket" && tag.getValue == value))
+        .exists(_.count() == testData.count(_ == value))
+
+    testMetric(MetricKey.frequency(name))(testData).map { searchResult =>
+      val bucketCounters = searchResult.counters().asScala
+      assertTrue(checkBucketCounter(bucketCounters, "Sample1") && checkBucketCounter(bucketCounters, "Sample2"))
+    }
+  }
+
+}

--- a/micrometer/src/test/scala/zio/metrics/connectors/micrometer/MicrometerMetricsSpec.scala
+++ b/micrometer/src/test/scala/zio/metrics/connectors/micrometer/MicrometerMetricsSpec.scala
@@ -24,7 +24,7 @@ object MicrometerMetricsSpec extends ZIOSpecDefault {
   ).provide(
     micrometerLayer,
     ZLayer.succeed(new SimpleMeterRegistry()),
-    ZLayer.succeed(MicroMeterConfig.default),
+    ZLayer.succeed(MicrometerConfig.default),
   ) @@ timed @@ timeoutWarning(60.seconds)
 
   private def testMetric[Type <: MetricKeyType](

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -7,4 +7,6 @@ object Version {
   val zio     = "2.0.4"
   val zioJson = "0.3.0"
   val zioHttp = "0.0.3"
+
+  val micrometer = "1.11.0"
 }

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -4,7 +4,7 @@ object Version {
   val Scala213   = "2.13.10"
   val ScalaDotty = "3.2.1"
 
-  val zio     = "2.0.4"
+  val zio     = "2.0.13"
   val zioJson = "0.3.0"
   val zioHttp = "0.0.3"
 

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -4,7 +4,7 @@ object Version {
   val Scala213   = "2.13.10"
   val ScalaDotty = "3.2.1"
 
-  val zio     = "2.0.13"
+  val zio     = "2.0.14"
   val zioJson = "0.3.0"
   val zioHttp = "0.0.3"
 


### PR DESCRIPTION
I am pleased to announce the successful integration of ZIO 2 Metrics with Micrometer, solving the problem of the lack of any universal connector of the ZIO ecosystem and the rest of the Java world in the context of metrics. This merge request introduces a seamless integration module that connects ZIO Metrics with Micrometer, allowing to translate all captured metric data from ZIO application to any of famous observability systems via common Micrometer facade.

## Benefits:

1. Standardized Metrics Collection: Micrometer is a widely adopted and standardized metrics library in the Java ecosystem. By integrating ZIO Metrics with Micrometer, we align our metrics collection approach with the industry-standard practices followed by the Java community. This ensures compatibility and interoperability with a wide range of existing monitoring systems, tools, and frameworks.

2. Universal facade (SLF4J but for metrics): Micrometer offers extensive support for various monitoring backends, including popular solutions like Prometheus, Datadog, Graphite, InfluxDB, and more. By integrating ZIO Metrics with Micrometer, we gain access to Micrometer's ecosystem of exporters, dashboards, and visualization tools. This allows us to leverage the existing integrations and take advantage of the rich features provided by Micrometer for metrics visualization, alerting, and analysis.

3. Easy Integration with Java Libraries: The integration of ZIO Metrics with Micrometer simplifies the integration of ZIO applications with other Java libraries and frameworks. Many Java libraries and frameworks already provide out-of-the-box integration with Micrometer, allowing us to seamlessly capture metrics from both ZIO and non-ZIO components of our applications. This facilitates a unified observability approach across the entire Java application stack.

4. Stay on Trend with Java Metrics Development: Micrometer is a popular and actively maintained metrics library in the Java ecosystem. By integrating ZIO Metrics with Micrometer, we align ourselves with the latest developments and updates in the Java metrics space. This ensures that our monitoring infrastructure stays up-to-date and can adapt to new features, formats, and backend updates introduced by Micrometer. No need to manually encode metrics for different end systems, such as Prometheus, Datadog, etc (like in other modules of zio-metric-connectors). Instead, the current format of the end system can be maintained centrally using Micrometer.

5. Real-time Metrics Updates: ZIO Metrics updates are immediately reflected in Micrometer, ensuring accurate monitoring.

## Technical details:

- The integration utilizes a low-level integration approach directly from the ZIO Metrics core client listener to Micrometer.
- The integration provides real-time synchronization between ZIO Metrics and Micrometer for accurate and timely monitoring. The module ensures immediate updates to Micrometer whenever metric changes occur within the ZIO application.
- Module depends on ZIO core and Micrometer core only.

## New document module was also added.

Please review this merge request, and I welcome any feedback or suggestions for further improvements.

Closes #24  #20
Probably closes #41

P.S. I am not sure that I did all requirements for proper document addition, I will be very grateful if you tell me how I can check the final documentation build.