### PR TITLE
Add missing link to datadog page in sidebar

### DIFF
--- a/docs/metrics/datadog-client.md
+++ b/docs/metrics/datadog-client.md
@@ -1,5 +1,5 @@
 ---
-id: metrics_datadog
+id: datadog-client
 title: "Datadog Client"
 ---
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -10,6 +10,7 @@ const sidebars = {
       items: [
         "metrics/metric-reference",
         "metrics/statsd-client",
+        "metrics/datadog-client",
         "metrics/prometheus-client",
         "metrics/micrometer-connector",
         "metrics/instrumentation-examples",


### PR DESCRIPTION
The documentation written for the datadog client is currently not visible in the project's [documentation page](https://zio.dev/zio-metrics-connectors/metrics/). This PR would fix that.