### PR TITLE
Updated zio version with metric key description and added its support to Prometheus and Micrometer metric connectors.

### DIFF
--- a/core/src/main/scala/zio/metrics/connectors/MetricsConfig.scala
+++ b/core/src/main/scala/zio/metrics/connectors/MetricsConfig.scala
@@ -6,9 +6,4 @@ final case class MetricsConfig(
   /**
    * Interval for polling metrics registry.
    */
-  interval: Duration,
-
-  /**
-   * Key name for MetricLabel used as description (currently in Prometheus connector only).
-   */
-  descriptionKey: String = "description")
+  interval: Duration)

--- a/core/src/test/scala/zio/metrics/connectors/Generators.scala
+++ b/core/src/test/scala/zio/metrics/connectors/Generators.scala
@@ -13,20 +13,19 @@ trait Generators {
 
   val nonEmptyString: Gen[Any, String] = Gen.alphaNumericString.filter(_.nonEmpty)
 
-  val descriptionKey = "testDescription"
-
   val genLabel: Gen[Any, MetricLabel] =
-    Gen.oneOf(Gen.const(descriptionKey), Gen.alphaNumericString).zipWith(Gen.alphaNumericString)(MetricLabel.apply)
+    Gen.alphaNumericString.zipWith(Gen.alphaNumericString)(MetricLabel.apply)
 
   val genTags: Gen[Any, Set[MetricLabel]] = Gen.setOf(genLabel)
 
   val genCounter: Gen[Any, (MetricPair.Untyped, MetricState.Counter)] = for {
-    name  <- nonEmptyString
-    tags  <- genTags
-    count <- Gen.double(1, 100)
+    name        <- nonEmptyString
+    description <- nonEmptyString
+    tags        <- genTags
+    count       <- Gen.double(1, 100)
   } yield {
     val state = MetricState.Counter(count)
-    (Unsafe.unsafe(implicit u => MetricPair.make(MetricKey.counter(name).tagged(tags), state)), state)
+    (Unsafe.unsafe(implicit u => MetricPair.make(MetricKey.counter(name, description).tagged(tags), state)), state)
   }
 
   def genCounterNamed(

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
@@ -8,10 +8,9 @@ import scala.jdk.CollectionConverters._
 
 import zio.{Unsafe, URIO, ZIO}
 import zio.metrics.{MetricKey, MetricKeyType, MetricListener}
-import zio.metrics.MetricKeyType.{Counter, Frequency, Gauge}
 import zio.metrics.connectors.micrometer.internal.AtomicDouble
 
-import io.micrometer.core.instrument.{DistributionSummary, Gauge => MGauge, MeterRegistry, Tag}
+import io.micrometer.core.instrument.{Counter, DistributionSummary, Gauge => MGauge, MeterRegistry, Tag}
 
 private[micrometer] class MicrometerMetricListener(
   meterRegistry: MeterRegistry,
@@ -24,12 +23,13 @@ private[micrometer] class MicrometerMetricListener(
     MGauge
       .builder(key.name, gaugeState, (v: AtomicDouble) => v.get())
       .tags(micrometerTags(key.tags).asJava)
+      .description(key.description.orNull)
       .strongReference(true)
       .register(meterRegistry)
     gaugeState
   }
 
-  private def getOrCreateGaugeRef(key: MetricKey[Gauge]): AtomicDouble =
+  private def getOrCreateGaugeRef(key: MetricKey[MetricKeyType.Gauge]): AtomicDouble =
     activeGauges.computeIfAbsent(key, newGaugeStateFunction)
 
   override def updateHistogram(
@@ -40,22 +40,23 @@ private[micrometer] class MicrometerMetricListener(
     DistributionSummary
       .builder(key.name)
       .tags(micrometerTags(key.tags).asJava)
+      .description(key.description.orNull)
       .serviceLevelObjectives(key.keyType.boundaries.values.filter(_ > 0): _*) // micrometer prohibits <= 0 slo values
       .register(meterRegistry)
       .record(value)
 
-  override def updateGauge(key: MetricKey[Gauge], value: Double)(implicit unsafe: Unsafe): Unit =
+  override def updateGauge(key: MetricKey[MetricKeyType.Gauge], value: Double)(implicit unsafe: Unsafe): Unit =
     getOrCreateGaugeRef(key).set(value)
 
-  override def modifyGauge(key: MetricKey[Gauge], value: Double)(implicit unsafe: Unsafe): Unit =
+  override def modifyGauge(key: MetricKey[MetricKeyType.Gauge], value: Double)(implicit unsafe: Unsafe): Unit =
     getOrCreateGaugeRef(key).incrementBy(value)
 
-  override def updateFrequency(key: MetricKey[Frequency], value: String)(implicit unsafe: Unsafe): Unit =
-    meterRegistry
-      .counter(
-        key.name,
-        (micrometerTags(key.tags) ++ Iterable(Tag.of("bucket", value))).asJava,
-      )
+  override def updateFrequency(key: MetricKey[MetricKeyType.Frequency], value: String)(implicit unsafe: Unsafe): Unit =
+    Counter
+      .builder(key.name)
+      .tags((micrometerTags(key.tags) ++ Iterable(Tag.of("bucket", value))).asJava)
+      .description(key.description.orNull)
+      .register(meterRegistry)
       .increment()
 
   override def updateSummary(
@@ -69,6 +70,7 @@ private[micrometer] class MicrometerMetricListener(
       .tags(
         (micrometerTags(key.tags) ++ Iterable(Tag.of("error", key.keyType.error.toString))).asJava,
       )
+      .description(key.description.orNull)
       .distributionStatisticBufferLength(key.keyType.maxSize)
       .distributionStatisticExpiry(key.keyType.maxAge)
       .publishPercentiles(key.keyType.quantiles: _*)
@@ -76,9 +78,12 @@ private[micrometer] class MicrometerMetricListener(
       .register(meterRegistry)
       .record(value)
 
-  override def updateCounter(key: MetricKey[Counter], value: Double)(implicit unsafe: Unsafe): Unit =
-    meterRegistry
-      .counter(key.name, micrometerTags(key.tags).asJava)
+  override def updateCounter(key: MetricKey[MetricKeyType.Counter], value: Double)(implicit unsafe: Unsafe): Unit =
+    Counter
+      .builder(key.name)
+      .tags(micrometerTags(key.tags).asJava)
+      .description(key.description.orNull)
+      .register(meterRegistry)
       .increment(value)
 }
 

--- a/micrometer/src/test/scala/zio/metrics/connectors/micrometer/MicrometerMetricsSpec.scala
+++ b/micrometer/src/test/scala/zio/metrics/connectors/micrometer/MicrometerMetricsSpec.scala
@@ -4,9 +4,9 @@ import java.time.Instant
 
 import scala.jdk.CollectionConverters._
 
-import zio.{durationInt, Chunk, ZIO, ZLayer}
+import zio.{durationInt, Chunk, Scope, ZIO, ZLayer}
 import zio.metrics.{Metric, MetricKey, MetricKeyType}
-import zio.test.{assertTrue, ZIOSpecDefault}
+import zio.test.{assertTrue, Spec, TestEnvironment, ZIOSpecDefault}
 import zio.test.TestAspect.{timed, timeoutWarning}
 
 import io.micrometer.core.instrument.MeterRegistry
@@ -15,17 +15,19 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 
 object MicrometerMetricsSpec extends ZIOSpecDefault {
 
-  override def spec = suite("The Micrometer registry should")(
-    testCounter,
-    testGauge,
-    testHistogram,
-    testSummary,
-    testFrequency,
-  ).provide(
-    micrometerLayer,
-    ZLayer.succeed(new SimpleMeterRegistry()),
-    ZLayer.succeed(MicrometerConfig.default),
-  ) @@ timed @@ timeoutWarning(60.seconds)
+  override def spec: Spec[TestEnvironment with Scope, Any] =
+    suite("The Micrometer registry should")(
+      testCounter,
+      testGauge,
+      testHistogram,
+      testSummary,
+      testFrequency,
+      testDescription,
+    ).provide(
+      micrometerLayer,
+      ZLayer.succeed(new SimpleMeterRegistry()),
+      ZLayer.succeed(MicrometerConfig.default),
+    ) @@ timed @@ timeoutWarning(60.seconds)
 
   private def testMetric[Type <: MetricKeyType](
     key: MetricKey[Type],
@@ -57,17 +59,16 @@ object MicrometerMetricsSpec extends ZIOSpecDefault {
     val testData = Seq(0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5)
     val buckets  = MetricKeyType.Histogram.Boundaries.linear(1, 1, 3)
 
-    testMetric(MetricKey.histogram(name, buckets))(testData).map(searchResult =>
-      assertTrue {
-        val resultSummary = searchResult.summary().takeSnapshot()
-        resultSummary.count() == testData.size &&
-        resultSummary.total() == testData.sum &&
-        resultSummary.max() == testData.max &&
+    testMetric(MetricKey.histogram(name, buckets))(testData).map { searchResult =>
+      val resultSummary = searchResult.summary().takeSnapshot()
+      assertTrue(
+        resultSummary.count() == testData.size.toLong,
+        resultSummary.total() == testData.sum,
+        resultSummary.max() == testData.max,
         resultSummary.histogramCounts().toSeq == buckets.values
-          .map(bound => new CountAtBucket(bound, testData.count(_ <= bound)))
-          .toSeq
-      },
-    )
+          .map(bound => new CountAtBucket(bound, testData.count(_ <= bound))),
+      )
+    }
   }
 
   private val testSummary = test("catch zio summary updates") {
@@ -75,12 +76,12 @@ object MicrometerMetricsSpec extends ZIOSpecDefault {
     val now         = Instant.now()
     val testData    = Chunk.fromIterable(1 to 1000).map(i => i.toDouble -> now)
     val percentiles = Chunk(0.1, 0.5, 0.9)
-    testMetric(MetricKey.summary(name, 1.day, 100, 0.03d, percentiles))(testData).map(searchResult =>
-      assertTrue {
-        val resultSummary = searchResult.summary().takeSnapshot()
-        resultSummary.count() == testData.size &&
-        resultSummary.total() == testData.map(_._1).sum &&
-        resultSummary.max() == testData.map(_._1).max &&
+    testMetric(MetricKey.summary(name, 1.day, 100, 0.03d, percentiles))(testData).map { searchResult =>
+      val resultSummary = searchResult.summary().takeSnapshot()
+      assertTrue(
+        resultSummary.count() == testData.size.toLong,
+        resultSummary.total() == testData.map(_._1).sum,
+        resultSummary.max() == testData.map(_._1).max,
         resultSummary
           .percentileValues()
           .toSeq
@@ -94,9 +95,9 @@ object MicrometerMetricsSpec extends ZIOSpecDefault {
             0.1 -> 100,
             0.5 -> 500,
             0.9 -> 900,
-          )
-      },
-    )
+          ),
+      )
+    }
   }
 
   private val testFrequency = test("catch zio frequency updates") {
@@ -110,8 +111,32 @@ object MicrometerMetricsSpec extends ZIOSpecDefault {
 
     testMetric(MetricKey.frequency(name))(testData).map { searchResult =>
       val bucketCounters = searchResult.counters().asScala
-      assertTrue(checkBucketCounter(bucketCounters, "Sample1") && checkBucketCounter(bucketCounters, "Sample2"))
+      assertTrue(checkBucketCounter(bucketCounters, "Sample1"), checkBucketCounter(bucketCounters, "Sample2"))
     }
+  }
+
+  private val testDescription = test("handle description") {
+    val description = "testDescription"
+
+    for {
+      gauge     <- testMetric(MetricKey.gauge("testDescGauge", description))(Seq(0)).map(_.gauge())
+      counter   <- testMetric(MetricKey.counter("testDescCounter", description))(Seq(0)).map(_.counter())
+      histogram <-
+        testMetric(
+          MetricKey.histogram("testDescHistogram", description, MetricKeyType.Histogram.Boundaries.fromChunk(Chunk(1))),
+        )(Seq(0)).map(_.summary())
+      summary   <- testMetric(
+                     MetricKey.summary("testDescSummary", description, 1.day, 100, 0.03d, Chunk(1)),
+                   )(Seq(0d -> Instant.now())).map(_.summary())
+      frequency <- testMetric(MetricKey.frequency("testDescFrequency", description))(Seq("str"))
+                     .map(_.counter())
+    } yield assertTrue(
+      gauge.getId.getDescription == description,
+      counter.getId.getDescription == description,
+      histogram.getId.getDescription == description,
+      summary.getId.getDescription == description,
+      frequency.getId.getDescription == description,
+    )
   }
 
 }

--- a/micrometer/src/test/scala/zio/metrics/connectors/micrometer/MicrometerMetricsSpec.scala
+++ b/micrometer/src/test/scala/zio/metrics/connectors/micrometer/MicrometerMetricsSpec.scala
@@ -65,8 +65,9 @@ object MicrometerMetricsSpec extends ZIOSpecDefault {
         resultSummary.count() == testData.size.toLong,
         resultSummary.total() == testData.sum,
         resultSummary.max() == testData.max,
-        resultSummary.histogramCounts().toSeq == buckets.values
-          .map(bound => new CountAtBucket(bound, testData.count(_ <= bound))),
+        resultSummary.histogramCounts().toList == buckets.values
+          .map(bound => new CountAtBucket(bound, testData.count(_ <= bound).toDouble))
+          .toList,
       )
     }
   }

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -4,7 +4,7 @@ object Version {
   val Scala213 = "2.13.11"
   val Scala3   = "3.3.0"
 
-  val zio     = "2.0.15"
+  val zio     = "2.0.16"
   val zioJson = "0.5.0"
   val zioHttp = "3.0.0-RC2"
 


### PR DESCRIPTION
After metric description field was added in ZIO 2.0.16 https://github.com/zio/zio/pull/8159 it became possible to make a proper supporting it in metric connectors.
Description support was added to Prometheus connector and Micrometer connector.