### PR TITLE
Expose the entity id to allow using Datadog origin detection

### DIFF
--- a/datadog/src/main/scala/zio/metrics/connectors/datadog/DatadogConfig.scala
+++ b/datadog/src/main/scala/zio/metrics/connectors/datadog/DatadogConfig.scala
@@ -20,6 +20,8 @@ import zio.{ULayer, ZLayer}
  *  The maximum number of metrics stored in the queue. This affects memory usage
  * @param containerId
  *  An optional docker container ID
+ * @param entityId
+ *  An optional entity ID value used with an internal tag for tracking client entity
  */
 final case class DatadogConfig(
   host: String,
@@ -28,6 +30,7 @@ final case class DatadogConfig(
   maxBatchedMetrics: Int = 10,
   maxQueueSize: Int = 100000,
   containerId: Option[String] = None,
+  entityId: Option[String] = None,
   sendUnchanged: Boolean = false)
 
 object DatadogConfig {

--- a/datadog/src/main/scala/zio/metrics/connectors/datadog/DatadogEncoder.scala
+++ b/datadog/src/main/scala/zio/metrics/connectors/datadog/DatadogEncoder.scala
@@ -26,15 +26,15 @@ case object DatadogEncoder {
   }
 
   private def addContextTags(s: StringBuilder, config: DatadogConfig): StringBuilder = {
+    val withEntityId    = config.entityId match {
+      case Some(eid) => s.append(eidString(eid))
+      case None      => s
+    }
     val withContainerId = config.containerId match {
       case Some(cid) => s.append(cidString(cid))
       case None      => s
     }
-    val withEntityId    = config.entityId match {
-      case Some(eid) => withContainerId.append(eidString(eid))
-      case None      => withContainerId
-    }
-    withEntityId
+    withContainerId
   }
 
   private def cidString(cid: String) = s"|c:$cid"

--- a/datadog/src/test/scala/zio/metrics/connectors/datadog/DatadogEncoderSpec.scala
+++ b/datadog/src/test/scala/zio/metrics/connectors/datadog/DatadogEncoderSpec.scala
@@ -7,7 +7,6 @@ import zio.metrics._
 import zio.metrics.MetricKeyType.Histogram.Boundaries
 import zio.metrics.connectors.MetricEvent
 import zio.test._
-import zio.test.Assertion._
 import zio.test.TestAspect._
 
 object DatadogEncoderSpec extends ZIOSpecDefault {
@@ -16,7 +15,9 @@ object DatadogEncoderSpec extends ZIOSpecDefault {
     sendHistogram,
     sendHistograms,
     encodeContainerId,
+    encodeEntityId,
     encodeHistogramWithContainerId,
+    encodeHistogramWithEntityId,
   ) @@ timed @@ timeoutWarning(60.seconds)
 
   private val sendHistogram = test("send histogram update") {
@@ -26,7 +27,7 @@ object DatadogEncoderSpec extends ZIOSpecDefault {
     val encoder  = DatadogEncoder.histogramEncoder(DatadogConfig.default)
     val key      = MetricKey.histogram(name, Boundaries(Chunk.empty)).tagged(tagName, tagValue)
     val encoded  = new String(encoder(key, NonEmptyChunk(1.0)).toArray)
-    assert(encoded)(equalTo(s"$name:1|d|#$tagName:$tagValue"))
+    assertTrue(encoded == s"$name:1|d|#$tagName:$tagValue")
   }
 
   private val sendHistograms = test("send histogram updates") {
@@ -36,7 +37,7 @@ object DatadogEncoderSpec extends ZIOSpecDefault {
     val encoder  = DatadogEncoder.histogramEncoder(DatadogConfig.default)
     val key      = MetricKey.histogram(name, Boundaries(Chunk.empty)).tagged(tagName, tagValue)
     val encoded  = new String(encoder(key, NonEmptyChunk(1.0, 2.0)).toArray)
-    assert(encoded)(equalTo(s"$name:1:2|d|#$tagName:$tagValue"))
+    assertTrue(encoded == s"$name:1:2|d|#$tagName:$tagValue")
   }
 
   private val encodeContainerId = test("encode container ID") {
@@ -47,7 +48,18 @@ object DatadogEncoderSpec extends ZIOSpecDefault {
     for {
       encoded <- encoder(event)
       s        = new String(encoded.toArray)
-    } yield assert(s)(equalTo(s"$name:1|g|c:$containerId"))
+    } yield assertTrue(s == s"$name:1|g|c:$containerId")
+  }
+
+  private val encodeEntityId = test("encode entity ID") {
+    val entityId = "aaa"
+    val name     = "m1"
+    val encoder  = DatadogEncoder.encoder(DatadogConfig.default.copy(entityId = Some(entityId)))
+    val event    = MetricEvent.New(MetricKey.gauge(name), MetricState.Gauge(1), Instant.now())
+    for {
+      encoded <- encoder(event)
+      s        = new String(encoded.toArray)
+    } yield assertTrue(s == s"$name:1|g|dd.internal.entity_id:$entityId")
   }
 
   private val encodeHistogramWithContainerId = test("encode histogram with container ID") {
@@ -58,7 +70,18 @@ object DatadogEncoderSpec extends ZIOSpecDefault {
     val encoder     = DatadogEncoder.histogramEncoder(DatadogConfig.default.copy(containerId = Some(containerId)))
     val key         = MetricKey.histogram(name, Boundaries(Chunk.empty)).tagged(tagName, tagValue)
     val encoded     = new String(encoder(key, NonEmptyChunk(1.0, 2.0)).toArray)
-    assert(encoded)(equalTo(s"$name:1:2|d|#$tagName:$tagValue|c:$containerId"))
+    assertTrue(encoded == s"$name:1:2|d|#$tagName:$tagValue|c:$containerId")
+  }
+
+  private val encodeHistogramWithEntityId = test("encode histogram with entity ID") {
+    val entityId = "aaa"
+    val name     = "testHistogram"
+    val tagName  = "testTag"
+    val tagValue = "tagValue"
+    val encoder  = DatadogEncoder.histogramEncoder(DatadogConfig.default.copy(entityId = Some(entityId)))
+    val key      = MetricKey.histogram(name, Boundaries(Chunk.empty)).tagged(tagName, tagValue)
+    val encoded  = new String(encoder(key, NonEmptyChunk(1.0, 2.0)).toArray)
+    assertTrue(encoded == s"$name:1:2|d|#$tagName:$tagValue|dd.internal.entity_id:$entityId")
   }
 
 }


### PR DESCRIPTION
Expose `entityId` that is added as a tag and allow using Datadog [origin detection](https://github.com/DataDog/java-dogstatsd-client#origin-detection-over-udp-and-uds).

In the [original implementation](https://github.com/DataDog/java-dogstatsd-client/blob/570a55a2d18198539c2444355fe06df53a859491/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java#L1218) they are getting it from the `DD_ENTITY_ID` environment variable if not provided. I didn't do it in order to mimic the `containerId` behavior, and this can be done in user code anyway.