### PR TITLE
Expose the entity id to allow using Datadog origin detection

### DIFF
--- a/datadog/src/main/scala/zio/metrics/connectors/datadog/DataDogEventProcessor.scala
+++ b/datadog/src/main/scala/zio/metrics/connectors/datadog/DataDogEventProcessor.scala
@@ -24,8 +24,7 @@ object DataDogEventProcessor {
                              val items  = queue.pollUpTo(datadogConfig.maxBatchedMetrics)
                              val values = groupMap(items)(_._1)(_._2)
                              values.foreach { case (key, value) =>
-                               val updatedKey = datadogConfig.entityId.fold(key)(key.tagged(entityTagName, _))
-                               val encoded    = encoder(updatedKey, NonEmptyChunk.fromChunk(value).get)
+                               val encoded = encoder(key, NonEmptyChunk.fromChunk(value).get)
                                client.send(encoded)
                              }
                            }
@@ -50,6 +49,4 @@ object DataDogEventProcessor {
     }
     result
   }
-
-  private val entityTagName: String = "dd.internal.entity_id"
 }

--- a/datadog/src/main/scala/zio/metrics/connectors/datadog/DataDogEventProcessor.scala
+++ b/datadog/src/main/scala/zio/metrics/connectors/datadog/DataDogEventProcessor.scala
@@ -24,7 +24,8 @@ object DataDogEventProcessor {
                              val items  = queue.pollUpTo(datadogConfig.maxBatchedMetrics)
                              val values = groupMap(items)(_._1)(_._2)
                              values.foreach { case (key, value) =>
-                               val encoded = encoder(key, NonEmptyChunk.fromChunk(value).get)
+                               val updatedKey = datadogConfig.entityId.fold(key)(key.tagged(entityTagName, _))
+                               val encoded    = encoder(updatedKey, NonEmptyChunk.fromChunk(value).get)
                                client.send(encoded)
                              }
                            }
@@ -49,4 +50,6 @@ object DataDogEventProcessor {
     }
     result
   }
+
+  private val entityTagName: String = "dd.internal.entity_id"
 }

--- a/datadog/src/main/scala/zio/metrics/connectors/datadog/DatadogConfig.scala
+++ b/datadog/src/main/scala/zio/metrics/connectors/datadog/DatadogConfig.scala
@@ -6,6 +6,7 @@ import zio.{ULayer, ZLayer}
 
 /**
  * Datadog Specific configuration
+ *
  * @param host
  *  Agent host name
  * @param port
@@ -20,6 +21,8 @@ import zio.{ULayer, ZLayer}
  *  The maximum number of metrics stored in the queue. This affects memory usage
  * @param containerId
  *  An optional docker container ID
+ * @param entityId
+ *  An optional entity ID value used with an internal tag for tracking client entity
  */
 final case class DatadogConfig(
   host: String,
@@ -28,6 +31,7 @@ final case class DatadogConfig(
   maxBatchedMetrics: Int = 10,
   maxQueueSize: Int = 100000,
   containerId: Option[String] = None,
+  entityId: Option[String] = None,
   sendUnchanged: Boolean = false)
 
 object DatadogConfig {

--- a/datadog/src/main/scala/zio/metrics/connectors/datadog/DatadogEncoder.scala
+++ b/datadog/src/main/scala/zio/metrics/connectors/datadog/DatadogEncoder.scala
@@ -42,7 +42,7 @@ case object DatadogEncoder {
   }
 
   private def makeStatsdEncoder(config: DatadogConfig): StatsdEncoder =
-    StatsdEncoder(config.entityId.map(eid => s"dd.internal.entity_id:$eid"))
+    StatsdEncoder(config.entityId.map(eid => MetricLabel("dd.internal.entity_id", eid)).toList)
 
   private def cidString(cid: String) = s"|c:$cid"
 }

--- a/datadog/src/main/scala/zio/metrics/connectors/datadog/DatadogEncoder.scala
+++ b/datadog/src/main/scala/zio/metrics/connectors/datadog/DatadogEncoder.scala
@@ -24,10 +24,11 @@ case object DatadogEncoder {
   def histogramEncoder(
     config: DatadogConfig,
   ): (MetricKey[MetricKeyType.Histogram], NonEmptyChunk[Double]) => Chunk[Byte] = {
+    val encoder = makeStatsdEncoder(config)
 
     def encodeHistogramValues(key: MetricKey[MetricKeyType.Histogram], values: NonEmptyChunk[Double]): StringBuilder = {
       val result = new StringBuilder(BUF_PER_METRIC)
-      makeStatsdEncoder(config).appendMetric(result, key.name, values, "d", key.tags)
+      encoder.appendMetric(result, key.name, values, "d", key.tags)
     }
 
     val base            = encodeHistogramValues _

--- a/datadog/src/test/scala/zio/metrics/connectors/datadog/DatadogEncoderSpec.scala
+++ b/datadog/src/test/scala/zio/metrics/connectors/datadog/DatadogEncoderSpec.scala
@@ -7,7 +7,6 @@ import zio.metrics._
 import zio.metrics.MetricKeyType.Histogram.Boundaries
 import zio.metrics.connectors.MetricEvent
 import zio.test._
-import zio.test.Assertion._
 import zio.test.TestAspect._
 
 object DatadogEncoderSpec extends ZIOSpecDefault {
@@ -16,7 +15,9 @@ object DatadogEncoderSpec extends ZIOSpecDefault {
     sendHistogram,
     sendHistograms,
     encodeContainerId,
+    encodeEntityId,
     encodeHistogramWithContainerId,
+    encodeHistogramWithEntityId,
   ) @@ timed @@ timeoutWarning(60.seconds)
 
   private val sendHistogram = test("send histogram update") {
@@ -26,7 +27,7 @@ object DatadogEncoderSpec extends ZIOSpecDefault {
     val encoder  = DatadogEncoder.histogramEncoder(DatadogConfig.default)
     val key      = MetricKey.histogram(name, Boundaries(Chunk.empty)).tagged(tagName, tagValue)
     val encoded  = new String(encoder(key, NonEmptyChunk(1.0)).toArray)
-    assert(encoded)(equalTo(s"$name:1|d|#$tagName:$tagValue"))
+    assertTrue(encoded == s"$name:1|d|#$tagName:$tagValue")
   }
 
   private val sendHistograms = test("send histogram updates") {
@@ -36,7 +37,7 @@ object DatadogEncoderSpec extends ZIOSpecDefault {
     val encoder  = DatadogEncoder.histogramEncoder(DatadogConfig.default)
     val key      = MetricKey.histogram(name, Boundaries(Chunk.empty)).tagged(tagName, tagValue)
     val encoded  = new String(encoder(key, NonEmptyChunk(1.0, 2.0)).toArray)
-    assert(encoded)(equalTo(s"$name:1:2|d|#$tagName:$tagValue"))
+    assertTrue(encoded == s"$name:1:2|d|#$tagName:$tagValue")
   }
 
   private val encodeContainerId = test("encode container ID") {
@@ -47,7 +48,18 @@ object DatadogEncoderSpec extends ZIOSpecDefault {
     for {
       encoded <- encoder(event)
       s        = new String(encoded.toArray)
-    } yield assert(s)(equalTo(s"$name:1|g|c:$containerId"))
+    } yield assertTrue(s == s"$name:1|g|c:$containerId")
+  }
+
+  private val encodeEntityId = test("encode entity ID") {
+    val entityId = "aaa"
+    val name     = "m1"
+    val encoder  = DatadogEncoder.encoder(DatadogConfig.default.copy(entityId = Some(entityId)))
+    val event    = MetricEvent.New(MetricKey.gauge(name), MetricState.Gauge(1), Instant.now())
+    for {
+      encoded <- encoder(event)
+      s        = new String(encoded.toArray)
+    } yield assertTrue(s == s"$name:1|g|#dd.internal.entity_id:aaa")
   }
 
   private val encodeHistogramWithContainerId = test("encode histogram with container ID") {
@@ -58,7 +70,18 @@ object DatadogEncoderSpec extends ZIOSpecDefault {
     val encoder     = DatadogEncoder.histogramEncoder(DatadogConfig.default.copy(containerId = Some(containerId)))
     val key         = MetricKey.histogram(name, Boundaries(Chunk.empty)).tagged(tagName, tagValue)
     val encoded     = new String(encoder(key, NonEmptyChunk(1.0, 2.0)).toArray)
-    assert(encoded)(equalTo(s"$name:1:2|d|#$tagName:$tagValue|c:$containerId"))
+    assertTrue(encoded == s"$name:1:2|d|#$tagName:$tagValue|c:$containerId")
+  }
+
+  private val encodeHistogramWithEntityId = test("encode histogram with entity ID") {
+    val entityId = "aaa"
+    val name     = "testHistogram"
+    val tagName  = "testTag"
+    val tagValue = "tagValue"
+    val encoder  = DatadogEncoder.histogramEncoder(DatadogConfig.default.copy(entityId = Some(entityId)))
+    val key      = MetricKey.histogram(name, Boundaries(Chunk.empty)).tagged(tagName, tagValue)
+    val encoded  = new String(encoder(key, NonEmptyChunk(1.0, 2.0)).toArray)
+    assertTrue(encoded == s"$name:1:2|d|#dd.internal.entity_id:aaa,$tagName:$tagValue")
   }
 
 }

--- a/statsd/src/main/scala/zio/metrics/connectors/statsd/StatsdEncoder.scala
+++ b/statsd/src/main/scala/zio/metrics/connectors/statsd/StatsdEncoder.scala
@@ -6,7 +6,7 @@ import zio._
 import zio.metrics._
 import zio.metrics.connectors._
 
-case object StatsdEncoder {
+case class StatsdEncoder(constantTags: Option[String]) {
 
   private val BUF_PER_METRIC = 128
 
@@ -96,7 +96,7 @@ case object StatsdEncoder {
     tags: Set[MetricLabel],
     extraTags: MetricLabel*,
   ): StringBuilder = {
-    val tagBuf      = new StringBuilder()
+    val tagBuf      = constantTags.fold(new StringBuilder())(new StringBuilder(_))
     val withTags    = appendTags(tagBuf, tags)
     val withAllTags = appendTags(withTags, extraTags)
 
@@ -130,3 +130,5 @@ case object StatsdEncoder {
   private lazy val format = new DecimalFormat("0.################")
 
 }
+
+object StatsdEncoder extends StatsdEncoder(None)

--- a/statsd/src/main/scala/zio/metrics/connectors/statsd/StatsdEncoder.scala
+++ b/statsd/src/main/scala/zio/metrics/connectors/statsd/StatsdEncoder.scala
@@ -6,7 +6,7 @@ import zio._
 import zio.metrics._
 import zio.metrics.connectors._
 
-case class StatsdEncoder(constantTags: List[MetricLabel]) {
+case class StatsdEncoder(constantTags: List[MetricLabel], suffix: Option[String]) {
 
   private val BUF_PER_METRIC = 128
 
@@ -120,9 +120,11 @@ case class StatsdEncoder(constantTags: List[MetricLabel]) {
       .append("|")
       .append(metricType)
 
-    if (withAllTags.nonEmpty) {
+    val result = if (withAllTags.nonEmpty) {
       withMetric.append("|#").append(tagBuf)
     } else withMetric
+
+    suffix.fold(result)(result.append)
   }
 
   private def appendTag(buf: StringBuilder, tag: MetricLabel): StringBuilder = {
@@ -137,4 +139,4 @@ case class StatsdEncoder(constantTags: List[MetricLabel]) {
 
 }
 
-object StatsdEncoder extends StatsdEncoder(Nil)
+object StatsdEncoder extends StatsdEncoder(Nil, None)

--- a/statsd/src/main/scala/zio/metrics/connectors/statsd/StatsdEncoder.scala
+++ b/statsd/src/main/scala/zio/metrics/connectors/statsd/StatsdEncoder.scala
@@ -6,9 +6,15 @@ import zio._
 import zio.metrics._
 import zio.metrics.connectors._
 
-case class StatsdEncoder(constantTags: Option[String]) {
+case class StatsdEncoder(constantTags: List[MetricLabel]) {
 
   private val BUF_PER_METRIC = 128
+
+  private val constantTagsFormatted: String = {
+    val tagBuf   = new StringBuilder()
+    val withTags = appendTags(tagBuf, constantTags)
+    withTags.toString()
+  }
 
   def encode(event: MetricEvent): Task[Chunk[Byte]] =
     ZIO.attempt(Chunk.fromArray(encodeEvent(event).toString().getBytes()))
@@ -96,7 +102,7 @@ case class StatsdEncoder(constantTags: Option[String]) {
     tags: Set[MetricLabel],
     extraTags: MetricLabel*,
   ): StringBuilder = {
-    val tagBuf      = constantTags.fold(new StringBuilder())(new StringBuilder(_))
+    val tagBuf      = new StringBuilder(constantTagsFormatted)
     val withTags    = appendTags(tagBuf, tags)
     val withAllTags = appendTags(withTags, extraTags)
 
@@ -131,4 +137,4 @@ case class StatsdEncoder(constantTags: Option[String]) {
 
 }
 
-object StatsdEncoder extends StatsdEncoder(None)
+object StatsdEncoder extends StatsdEncoder(Nil)


### PR DESCRIPTION
Expose `entityId` that is added as a tag and allow using Datadog [origin detection](https://github.com/DataDog/java-dogstatsd-client#origin-detection-over-udp-and-uds).

In the [original implementation](https://github.com/DataDog/java-dogstatsd-client/blob/570a55a2d18198539c2444355fe06df53a859491/src/main/java/com/timgroup/statsd/NonBlockingStatsDClient.java#L1218) they are getting it from the `DD_ENTITY_ID` environment variable if not provided. I didn't do it in order to mimic the `containerId` behavior, and this can be done in user code anyway.

Because `DatadogEncoder` can't modify tags, I modified `StatsdEncoder` to allow passing constant tags that are added to every metric event. Using a `String` is more efficient than adding tags as it doesn't need to be formatted every time. The dogstatsd has a similar approach.