### PR TITLE
Replace space and dot by underscore in Prometheus metric names

### DIFF
--- a/prometheus/src/main/scala/zio/metrics/connectors/prometheus/PrometheusEncoder.scala
+++ b/prometheus/src/main/scala/zio/metrics/connectors/prometheus/PrometheusEncoder.scala
@@ -16,7 +16,7 @@ case object PrometheusEncoder {
     state: MetricState.Untyped,
     timestamp: Instant,
   ): Chunk[String] = {
-    val name = key.name.replaceAll("-", "_").trim
+    val name = key.name.replaceAll("[- \\.]", "_").trim
 
     // The header required for all Prometheus metrics
     val prometheusType = state match {


### PR DESCRIPTION
Prometheus metric names must follow the regex `[a-zA-Z_][a-zA-Z0-9_]*` (source: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels).

Currently `-` is replaced automatically by `_`. I think it makes sense to also catch space and dot (actually, we did use dots and broke our metrics 😭 ).