### PR TITLE
Refactor documentation, use zio-http RC4 in example app

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,7 @@ lazy val newrelic =
     .settings(
       stdSettings("zio.metrics.connectors.newrelic"),
       libraryDependencies ++= Seq(
-        "dev.zio"  %% "zio-http" % Version.zioHttp,
+        "dev.zio"  %% "zio-http" % "3.0.0-RC2", // TODO: update newrelic client to use `Version.zioHttp`
         "dev.zio" %%% "zio-json" % Version.zioJson,
       ),
     )

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,29 +5,34 @@ title: "Getting Started"
 
 ZIO Metrics lets you observe everything that goes on in your ZIO application.
 
-Tests are important for verifying the correctness of the code we write. However, when we go into production conditions 
-are inevitably different than in testing and we need to know what is going on in our application in real time so we 
-can diagnose and address problems.
+Tests are important for verifying the correctness of the code we write. However, when we go into production conditions
+are inevitably different than in testing. Still, we do need to know what is going on in our application in real time so
+that we can diagnose and address problems.
 
-Logging is part of the solution but it is not enough. We either only log in certain areas, which are often not the 
+Logging is part of the solution, but it is not enough. We either only log in certain areas, which are often not the
 areas where an issue actually occurs, or we log everywhere, significantly impacting application performance.
 
-Diagnostics and metrics are the other piece of the puzzle, but there has not been a solution for integrating existing 
-metrics backends with functional effect systems before, forcing users to develop their own workarounds. These solutions 
-are not connected with the runtime of the effect system, so they have no ability to provide insights on what is going 
+Diagnostics and metrics are the other pieces of the puzzle, but there has not been a solution for integrating existing
+metrics backends with functional effect systems before, forcing users to develop their own workarounds. These solutions
+are not connected with the runtime of the effect system, so they have no ability to provide insights on what is going
 on at the level of the runtime such as the activity of individual fibers.
 
-ZIO Metrics solves this problem. ZIO Metrics can be added to any application with only a few lines of code and provides 
+ZIO Metrics solves this problem. ZIO Metrics can be added to any application with only a few lines of code and provides
 two types of insights:
 
- - **Diagnostics** — Diagnostics are pre-defined data on the behavior of the application as it is running provided directly by the ZIO runtime, such as the number of fibers in the application, distribution of fiber lifetimes, and breakdown of fiber reasons for termination.
- - **[Metrics](metrics/metric-reference.md)** — Metrics are used-defined data, such as the number of times a certain section of code was executed, that are tracked by ZIO Metrics and made available either directly or through third party metrics solutions such as Prometheus, StatsD or Micrometer.
+- **Diagnostics** — Diagnostics are pre-defined data on the behavior of the application as it is running directly by the
+  ZIO runtime, such as the number of fibers in the application, distribution of fiber lifetimes, and a breakdown of
+  reasons for fiber termination.
+- **[Metrics](metrics/metric-reference.md)** — Metrics are used-defined data, such as the number of times a certain
+  section of code was executed, that are tracked by ZIO Metrics and made available either directly or through third
+  party metrics solutions such as Prometheus, StatsD or Micrometer.
 
 See the corresponding sections for more information on how to use each of these pieces of functionality.
 
 ## Installation
 
-Choose and include ZIO Metrics connector in your project by adding the following to your `build.sbt` (for example prometheus connector):
+Choose and include ZIO Metrics connector in your project by adding the following to your `build.sbt` (for example
+prometheus connector):
 
 ```scala mdoc:passthrough
 

--- a/docs/metrics/index.md
+++ b/docs/metrics/index.md
@@ -2,23 +2,29 @@
 id: index
 title: "Metrics"
 ---
-ZIO Metrics enables the instrumentation of any ZIO based application with specialized aspects. The type of the original ZIO effect will not change by adding on or more aspects to it. 
+ZIO Metrics allows you to apply special aspects to the workflows of any ZIO based application. This is called
+instrumentation. The type of the original ZIO workflow will not change by adding one or more aspects to it. (From here
+on, we'll use the word _effect_ instead of workflow.)
 
-Whenever an instrumented effect executes, all the aspects will be executed as well and each of the 
-aspects will capture some data of interest and update some Metric internal state. Which data will be captured and how it can be used later on is dependent on the metric type associated with the aspect. 
+Whenever an instrumented effect executes, all the aspects will be executed as well. Each of the aspects will capture
+some data of interest and update some Metric internal state. Which data will be captured and how it can be used later on
+is dependent on the metric type associated with the aspect. Capturing metrics data is usually called 'measuring'.
 
-Metrics are normally captured to be displayed in an application like [Grafana](https://grafana.com/) or a cloud based platform like [DatadogHQ](https://docs.datadoghq.com/) 
-or [NewRelic](https://newrelic.com). 
-In order to support such a range of different platforms, the metric state is kept in an internal data structure optimized to update the state as efficiently as possible 
-and the data required by one or more of the platforms is generated only when it is required. 
+Metrics are normally collected to be displayed in an application like [Grafana](https://grafana.com/) or a cloud based
+platform like [DatadogHQ](https://docs.datadoghq.com/) or [NewRelic](https://newrelic.com).
+In order to support such a range of different platforms, the metric state is kept in an internal data structure which is
+optimized to update as efficiently as possible. The data required by the collecting platforms is generated only when it
+is required.
 
-ZIO Metrics Connectors also allows us to dump current metric states (in one of the next minor releases) out of the box to analyze the metrics in the development phase before the decision 
-for a metric platform has been made or in cases when the platform might not be feasible to use in development. 
+ZIO Metrics Connectors also allows us to dump current metric states (in one of the next minor releases) out of the box
+to analyze the metrics in the development phase before the decision for a metric platform has been made or in cases when
+the platform might not be feasible to use in development.
 
-> Changing the targeted reporting back end will have no impact on the application at all. Once instrumented properly, that reporting back end decision will happen __at the end of the world__
-> in the ZIO applications mainline by injecting one or more of the available reporting clients.
+> Changing which platform the metrics are reported to has no impact on the application at all. Once instrumented
+> properly, the decision where to report to happens 'at the end of the world', that is, in the ZIO application's main
+> entry point, by providing one or more of the available reporting clients.
 
-Currently, ZIO Metrics Connectors provides integrations with the following backends:
+Currently, ZIO Metrics Connectors provides integrations with the following reporting clients:
 * [Prometheus](https://prometheus.io/)
 * [Datadog](https://docs.datadoghq.com/)
 * [New Relic](https://newrelic.com)
@@ -41,26 +47,7 @@ libraryDependencies ++= {
 }
 ```
 
-## General Metric architecture
-
-All metrics have a name of type `String` which may be augmented by zero or many `Label`s. A `Label` is simply a key/value pair to further qualify the name. 
-The distinction is made, because some reporting platforms support tags as well and provide certain aggregation mechanisms for them. 
-
-> For example, think of a counter that simply counts how often a particular service has been invoked. If the application 
-> is deployed across several hosts, we might model our counter with a name `myService`and an additional label 
-> `(host, ${hostname})`. With such a definition we would see the number of executions for each host, but we could also 
-> create a query in Grafana or DatadogHQ to visualize the aggregated value over all hosts. Using more than one label 
-> would allow to create visualizations across any combination of the labels. 
-
-An important aspect of metric aspects is that they _understand_ values of a certain type. For example, a Gauge 
-understands `Double` values to manipulate the current value within the gauge. This implies, that for effects 
-`ZIO[R, E, A]` where `A` can not be assigned to a `Double` we have to provide a mapping function `A => Double` so that 
-we can derive the measured value from the effect´s result. 
-
-Finally, more complex metrics might require additional information to specify them completely. For example, within a 
-[histogram](metric-reference.md#histograms) we need to specify the buckets the observed values shall be counted in. 
-
-Please refer to 
+Please refer to:
 
 * [Metrics Reference](metric-reference.md) for more information on the metrics currently supported
 * [Prometheus Client](prometheus-client.md) to learn more about the mapping from ZIO Metrics to Prometheus

--- a/docs/metrics/instrumentation-examples.md
+++ b/docs/metrics/instrumentation-examples.md
@@ -8,44 +8,48 @@ import zio._
 import zio.metrics._
 ```
 
-The trait below is used in the ZIO Metrics sample application just to show how the individual aspects 
-can be configured and used. 
+The trait below is used in the
+[zio metrics sample application](https://github.com/zio/zio-metrics-connectors/blob/docs/sample-app/src/main/scala/sample/SamplePrometheusStatsDApp.scala)
+that is provided in the zio-metrics-connectors repository on GitHub. It shows how the individual metrics can be
+configured and used.
 
-Please refer to [StatsD](statsd-client.md) and [Prometheus](prometheus-client.md) to see how the captured 
-metrics can be visualized in the supported back ends. 
+Please refer to [StatsD](statsd-client.md) and [Prometheus](prometheus-client.md) to see how the captured metrics can be
+visualized in the supported back ends.
 
 ```scala mdoc
 trait InstrumentedSample {
 
   // Create a gauge, it can be applied to effects yielding a Double
-  val aspGauge1 = Metric.gauge("gauge1")
+  val aspGauge1 = Metric.gauge("gauge1", "Description of gauge1")
+    .tagged("tag1", "tag value")
+    .tagged("tag2", "anoter tag value")
 
   val aspGauge2 = Metric.gauge("gauge2")
 
   // Create a histogram with 12 buckets: 0..100 in steps of 10, Infinite
   // It also can be applied to effects yielding a Double
   val aspHistogram =
-    Metric.histogram("myHistogram", MetricKeyType.Histogram.Boundaries.linear(0.0d, 10.0d, 11))
+    Metric.histogram("my_histogram", MetricKeyType.Histogram.Boundaries.linear(0.0d, 10.0d, 11))
 
   // Create a summary that can hold 100 samples, the max age of the samples is 1 day.
   // The summary should report th 10%, 50% and 90% Quantile
   // It can be applied to effects yielding an Int
   val aspSummary =
-    Metric.summary("mySummary", 1.day, 100, 0.03d, Chunk(0.1, 0.5, 0.9)).contramap[Int](_.toDouble)
+    Metric.summary("my_summary", 1.day, 100, 0.03d, Chunk(0.1, 0.5, 0.9)).contramap[Int](_.toDouble)
 
   // Create a Set to observe the occurrences of unique Strings
   // It can be applied to effects yielding a String
-  val aspSet = Metric.frequency("mySet")
+  val aspSet = Metric.frequency("my_set")
 
   // Create a counter applicable to any effect
-  val aspCountAll = Metric.counter("countAll").contramap[Any](_ => 1L)
+  val aspCountAll = Metric.counter("count_all").contramap[Any](_ => 1L)
 
   private lazy val gaugeSomething = for {
     _ <- Random.nextDoubleBetween(0.0d, 100.0d) @@ aspGauge1 @@ aspCountAll
     _ <- Random.nextDoubleBetween(-50d, 50d) @@ aspGauge2 @@ aspCountAll
   } yield ()
 
-  // Just record something into a histogram
+  // Record something into a histogram
   private lazy val observeNumbers = for {
     _ <- Random.nextDoubleBetween(0.0d, 120.0d) @@ aspHistogram @@ aspCountAll
     _ <- Random.nextIntBetween(100, 500) @@ aspSummary @@ aspCountAll
@@ -53,7 +57,7 @@ trait InstrumentedSample {
 
   // Observe Strings in order to capture unique values
   private lazy val observeKey = for {
-    _ <- Random.nextIntBetween(10, 20).map(v => s"myKey-$v") @@ aspSet @@ aspCountAll
+    _ <- Random.nextIntBetween(10, 20).map(v => s"my_key_$v") @@ aspSet @@ aspCountAll
   } yield ()
 
   def program: ZIO[Any, Nothing, Unit] = for {

--- a/docs/metrics/metric-reference.md
+++ b/docs/metrics/metric-reference.md
@@ -8,79 +8,115 @@ import zio._
 import zio.metrics._
 ```
 
-All ZIO metrics are defined in the form of aspects that can be applied to effects without changing
-the signature of the effect it is applied to.
+## Measuring
 
-Also, every `Metric`s implementation are further qualified by a type parameter `In` that must be compatible with
-the output type of the effect. Practically this means that, for example, a `Metric.Counter[Any]` can be applied
-to any effect while a `Metric.Counter[Double]` can only be applied to effects producing a `Double`.
-
-Finally, each metric understands a certain data type it can observe to manipulate its state.
-Counters, Gauges, Histograms and Summaries all understand `Double` values while a Frequency understands
-`String` values.
-
-In cases where the output type of effect is not compatible with the type required to manipulate the
-metric, the API defines a `contramap` method to construct a `Metric[_, In2, _]` with a mapper function
-from `In` to the type required by the metric.
-
-There is also an ability to set up additional conditions for metric value capture.
-Such methods like `trackAll`, `trackDefectWith`, `trackDurationWith`, `trackErrorWith` and `trackSuccessWith` allow for
-customized tracking based on specific criteria. This flexibility enables us to define our own tracking logic and metrics
-based on the requirements of our application. For example, we can track defects only when certain conditions are met or
-track the duration of specific ZIO effects.
-The ZIO Metric methods like `trackErrorWith` allow capturing and tracking
-errors in ZIO effects.
-Each of this help methods returns new `ZIOAspect`, for example:
+All ZIO metrics are defined in the form of aspects that can be applied with `@@` to measure an effect. Applying an
+aspect to an effect does not change the type of the effect. For example:
 
 ```scala
-val countAllErrors: ZIOAspect[Nothing, Any, Nothing, Any, Nothing, Any] = Metric.counter("countAllErrors").contramap[Any](_ => 1L).trackError
+val metric = Metric.counter("effect_counter")
+val effect: ZIO[Any, Throwable, Double] = ???
+val effectWithMeasurement: ZIO[Any, Throwable, Double] = effect @@ metric
 ```
 
-It is possible to add some custom tag to Metric via `tagged()` methods.
+### Name, description and labels
+
+Every metric has a name and optionally a description. The name may be augmented by zero or more `Label`s (sometimes
+called `tag`s). Labels are useful, because some reporting platforms support them and provide aggregation mechanisms
+for them.
+
+> For example, think of a counter that counts how often a particular service has been invoked. If the application is
+> deployed across several hosts, we can model our counter with the name `my_service` and an additional label
+> `(host, ${hostname})`. With this definition we can see the number of executions for each host, but we can also
+> create a query in Grafana or DatadogHQ to visualize the aggregated value over all hosts. Using more than one label
+> allows us to create visualizations across any combination of the labels.
+
+Name and description are always given as part of the metric constructor, labels can be added via one of the `tagged`
+methods. Here is an example:
 
 ```scala
-val countRequests = Metric.counter("countRequests")
-
-val countRequestsByPath = for {
-  _ <- requestLogic @@ countRequests.tagged("path", path)
-} yield ()
+val countRequests = Metric.counter("count_requests", "Description of the counter").tagged("hostname", hostname)
+val effect: ZIO[Any, Throwable, Double] = ???
+val effectWithTaggedMeasurement = effect @@ countRequests.tagged("path", path)
 ```
 
-The API functions in this document are implemented in the `Metric` object. An aspect can be applied to
-an effect with the `@@` operator.
+We recommend you follow the [Prometheus best practices](https://prometheus.io/docs/practices/naming/) guide for the metric name and labels.
 
-Once an application is instrumented with Metric aspects, it can be configured with a client implementation
-that is responsible for providing the captured metrics to an appropriate backend. Currently, ZIO Metrics supports
-clients for [StatsD](statsd-client.md) and [Prometheus](prometheus-client.md) out of the box.
+### Supported type
+
+Every `Metric` has the type parameter `In` which indicates what types of values can be measured by the metric. When
+applying the metric as an aspect to an effect, the metric's `In` type must be compatible with the output type of the
+effect (the `A` in `ZIO[R, E, A]`). For example, a `Metric.Counter[Any]` can be applied to any effect while a
+`Metric.Counter[Double]` can only be applied to an effect that produces a `Double`.
+
+In the underlying implementation, each metric type supports only one base type. _Counters_, _Gauges_, _Histograms_ and
+_Summaries_ all support `Double` values, while a _Frequency_ supports `String` values. To support a different type, we
+can use the `contramap` method. For example, a Gauge that supports `Long`s is written as:
+
+```scala
+val longGauge: Metrics.Gauge[Long] =
+  Metric.Gauge("my_metric").contramap[Long](_.toDouble)
+```
+
+Method `fromConst` works like `contramap` but always returns the same value. For example a counter that always increases
+with the same value is written as:
+
+```scala
+val occurrenceCounter: Metric.Counter[Any] =
+  Metric.counter("my_metric").fromConst(1L)
+```
+
+### Measuring durations
+
+To measure how long an effect takes, we can use methods `trackDuration` and `trackDurationWith`. See the histogram
+section below for an example.
+
+### Measuring failures
+
+Normally, we only measure effects that succeed. To measure an effect that failed, we can use methods like `trackAll`,
+`trackDefectWith`, `trackErrorWith` and `trackSuccessWith`. For example `trackError` lets you measure the error output
+of an effect:
+
+```scala
+val countAllErrors =
+  Metric.counter("all_errors").fromConst(1L).trackError
+
+// counts the errors of `effect`
+val effectWithMeasurement = effect @@ countAllErrors
+```
+
+# Metric types
 
 ## Counter
 
-A counter is simply a named variable that increases over time.
-
-### API
-
-Create a counter which is incremented by value produced by effect every time it is executed successfully. This can be
-applied to any effect.
+A counter is a metric of which the value can only increase over time. A counter can be created with one of these
+methods:
 
 ```scala
-def counter(name: String): Metric.Counter[Long]
+val longCounter: Metric.Counter[Long] = Metric.counter(name = "my_metric")
+val intCounter: Metric.Counter[Int] = Metric.counterInt(name = "my_metric")
+val doubleCounter: Metric.Counter[Double] = Metric.counterDouble(name = "my_metric")
+```
 
-def counterDouble(name: String): Metric.Counter[Double]
+Besides using a counter as an aspect (with the `@@` operator), counter metrics can also measure values with their
+`increment` and `incrementBy` methods. For example:
 
-def counterInt(name: String): Metric.Counter[Int]
+```scala
+longCounter.incrementBy(10L)
 ```
 
 ### Examples
 
-Create a counter named `countAll` which is incremented by `1` every time it is invoked.
+Create a counter named `count_all` which is incremented by `1` every time it is invoked. Since the metric type is `Any`
+the aspect can be applied to effect of any type.
 
 ```scala 
-val aspCountAll = Metric.counter("countAll").contramap[Any](_ => 1L)
+val aspCountAll: Metric.Counter[Any] =
+  Metric.counter("count_all").fromConst(1L)
 ```
 
-After contramap to Any, the counter can be applied to any effect. Note, that the same aspect can be applied
-to more than one effect. In the example we would count the sum of executions of both effects
-in the for comprehension.
+The same aspect can be applied to more than one effect. In the following example we count the sum of executions of both
+effects in the for comprehension:
 
 ```scala 
 val countAll = for {
@@ -89,14 +125,14 @@ val countAll = for {
 } yield ()
 ```  
 
-Create a counter named `countBytes` that can be applied to effects having the output type `Double`.
+Create a counter named `count_bytes` that can be applied to effects having the output type `Double`.
 
 ```scala
-val aspCountBytes = Metric.counterDouble("countBytes")
+val aspCountBytes = Metric.counterDouble("count_bytes")
 ```
 
-Now we can apply it to effects producing `Double` (in a real application the value might be
-the number of bytes read from a stream or something similar):
+Now we can apply it to effects producing `Double` (in a real application the value might be the number of bytes read
+from a stream or something similar):
 
 ```scala 
 val countBytes = nextDoubleBetween(0.0d, 100.0d) @@ aspCountBytes
@@ -104,76 +140,100 @@ val countBytes = nextDoubleBetween(0.0d, 100.0d) @@ aspCountBytes
 
 ## Gauges
 
-A gauge is a named variable of type `Double` that can change over time. It can either be set
-to an absolute value or relative to the current value.
-
-### API
-
-Create a gauge that can be set to absolute values. It can be applied to effects yielding a Double
+A gauge is a metric that can change over time. A gauge can be created as follows:
 
 ```scala
-def gauge(name: String): Metric.Gauge[Double]
+val doubleGauge: Metric.Gauge[Double] = Metric.gauge(name = "my_metric")
+```
+
+Besides using a gauge as an aspect (with the `@@` operator), gauge metrics can also measure values with their `set`,
+`increment`, `incrementBy`, `decrement` and `decrementBy` methods. For example:
+
+```scala
+for {
+  _ <- doubleGauge.set(10.0) // sets the gauge to 10.0
+  _ <- doubleGauge.decrement // decreases the gauge with 1.0
+} yield ()
 ```
 
 ### Examples
 
-Create a gauge that can be set to absolute values, it can be applied to effects yielding a Double
+Create a gauge that can be applied to effects that produce a Double:
 
 ```scala
-val aspGauge = Metric.gauge("setGauge")
+val aspGauge = Metric.gauge("set_gauge")
 ```
 
-Now we can apply these aspects to effects having an output type `Double`. Note that we can instrument
-an effect with any number of aspects if the type constraints are satisfied.
+Now we can apply the metric to effects that produce `Double`s. Note that we can instrument an effect with any number of
+aspects if the type constraints are satisfied.
 
 ```scala 
-val gaugeSomething = for {
-  _ <- nextDoubleBetween(0.0d, 100.0d) @@ aspGauge @@ aspCountAll
-} yield ()
+val measuredEffect = nextDoubleBetween(0.0d, 100.0d) @@ aspGauge @@ aspCountAll
 ```
 
 ## Histograms
 
-A histogram observes `Double` values and counts the observed values in buckets. Each bucket is defined
-by an upper boundary and the count for a bucket with the upper boundary `b` increases by `1` if an observed
-value `v` is less or equal to `b`.
-
-As a consequence, all buckets that have a boundary `b1` with `b1 > b` will increase by `1` after observing `v`.
+A histogram is a metric that counts the measured values in buckets. Each bucket is defined by an upper boundary. The
+count in a bucket with upper boundary `b` increases by `1` if an observed value `v` is less or equal to `b`. As a
+consequence, all buckets that have a boundary `b1` with `b1 > b` will increase by `1` after observing `v`.
 
 A histogram also keeps track of the overall count of observed values and the sum of all observed values.
 
-By definition, the last bucket is always defined as `Double.MaxValue`, so that the count of observed values in
-the last bucket is always equal to the overall count of observed values within the histogram.
+The last bucket is always defined as `Double.MaxValue`, so that the count of observed values in the last bucket is
+always equal to the overall count of observed values within the histogram.
 
-To define a histogram aspect, the API requires that the boundaries for the histogram are specified when creating
-the aspect.
+The used histogram model is inspired by [Prometheus](https://prometheus.io/docs/concepts/metric_types/#histogram).
 
-The mental model for a histogram is inspired
-from [Prometheus](https://prometheus.io/docs/concepts/metric_types/#histogram).
-
-### API
-
-Create a histogram that can be applied to effects producing `Double` values. The values will be counted as outlined
-above.
+Boundaries can be created as follows:
 
 ```scala
-def histogram(name: String, boundaries: Histogram.Boundaries): Metric.Histogram[Double]
+// given boundaries: 100.0, 200.0, 300.0, 400.0, MaxValue
+MetricKeyType.Histogram.Boundaries.fromChunk(Chunk(100.0, 200.0, 300.0, 400.0))
+// linear boundaries: 100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0, 900.0, 1000.0, MaxValue
+MetricKeyType.Histogram.Boundaries.linear(100.0, 100.0, 10)
+// exponential boundaries: 100.0, 200.0, 400.0, 800.0, 1600.0, 3200.0, 6400.0, 12800.0, 25600.0, 51200.0, MaxValue
+MetricKeyType.Histogram.Boundaries.exponential(100.0, 2.0, 10)
+```
+
+A histogram can be created with the `Metric.histogram(name, boundaries)` method. For example:
+
+```scala
+val latencyHistogram: Metric.Histogram[Double] =
+  Metric.histogram("queue_size", boundaries)
 ```
 
 ### Examples
 
-Create a histogram with 12 buckets: `0..100` in steps of `10` and `Double.MaxValue`. It can be applied to effects
+Create a histogram with 10 buckets: `0..100` in steps of `10` and `Double.MaxValue`. It can be applied to effects
 yielding a `Double`.
 
 ```scala 
 val aspHistogram =
-  Metric.histogram("myHistogram", Histogram.Boundaries.linear(0.0d, 10.0d, 11))
+  Metric.histogram("my_histogram", Histogram.Boundaries.linear(0.0d, 10.0d, 10))
 ```
 
 Now we can apply the histogram to effects producing `Double`:
 
 ```scala 
-val histogram = nextDoubleBetween(0.0d, 120.0d) @@ aspHistogram 
+val measuredEffect = nextDoubleBetween(0.0d, 120.0d) @@ aspHistogram 
+```
+
+Create a histogram that observes `Duration`s in seconds. Use `trackDuration` to track the duration of an effect.
+Note that using seconds as unit is the recommended convention in many metric platforms such as Prometheus and
+OpenTelemetry.
+
+```scala
+val latencyHistogram: Metric.Histogram[Duration] =
+  Metric.histogram(
+      "my_latency_seconds",
+      "The latency in seconds.",
+      MetricKeyType.Histogram.Boundaries.exponential(0.01, 2.0, 10)
+    )
+    .contramap[Duration](_.toNanos.toDouble / 1e9) // convert to seconds
+
+val effect: ZIO[Any, Throwable, Unit] = ???
+
+effect @@ latencyHistogram.trackDuration
 ```
 
 ## Summaries
@@ -186,28 +246,22 @@ calculate the statistics, maximal `n` samples will be used, all of which are not
 Essentially the set of samples is a sliding window over the last observed samples matching the conditions above.
 
 A summary is used to calculate a set of quantiles over the current set of samples. A quantile is defined by a `Double`
-value `q`
-with `0 <= q <= 1` and resolves to a `Double` as well.
+value `q` with `0 <= q <= 1` and resolves to a `Double` as well.
 
-The value of a given quantile `q` is the maximum value `v` out of the current sample buffer with size `n` where at
-most `q * n`
-values out of the sample buffer are less or equal to `v`.
+The value of a given quantile `q` is the maximum value `v` out of the current sample buffer with size `n` where at most
+`q * n` values out of the sample buffer are less or equal to `v`.
 
 Typical quantiles for observation are `0.5` (the median) and the `0.95`. Quantiles are very good for monitoring Service
 Level Agreements.
 
-The ZIO Metrics API also allows summaries to be configured with an error margin `e`. The error margin is applied to the count of
-values, so that a
-quantile `q` for a set of size `s` resolves to value `v` if the number `n` of values less or equal to `v`
-is `(1 -e)q * s <= n <= (1+e)q`.
+The ZIO Metrics API also allows summaries to be configured with an error margin `e`. The error margin is applied to the
+count of values, so that a quantile `q` for a set of size `s` resolves to value `v` if the number `n` of values less or
+equal to `v` is `(1 -e)q * s <= n <= (1+e)q`.
 
-### API
-
-A metric aspect that adds a value to a summary each time the effect it is applied to succeeds. This aspect can be
-applied to effects producing a `Double`.
+A summary can be created with the `summary` method:
 
 ```scala
-def summary(
+Metric.summary(
   name: String,
   maxAge: Duration,
   maxSize: Int,
@@ -218,13 +272,12 @@ def summary(
 
 ### Examples
 
-Create a summary that can hold 100 samples, the max age of the samples is `1 day` and the
-error margin is `3%`. The summary should report the `10%`, `50%` and `90%` Quantile.
-It can be applied to effects yielding an `Int`.
+Create a summary that can hold 100 samples, the max age of the samples is `1 day` and the error margin is `3%`. The
+summary should report the `10%`, `50%` and `90%` quantiles. It can be applied to effects producing an `Int`.
 
 ```scala
 val aspSummary =
-  Metric.summary("mySummary", 1.day, 100, 0.03d, Chunk(0.1, 0.5, 0.9)).contramap[Int](_.toDouble)
+  Metric.summary("my_summary", 1.day, 100, 0.03d, Chunk(0.1, 0.5, 0.9)).contramap[Int](_.toDouble)
 ```
 
 Now we can apply this aspect to an effect producing an `Int`:
@@ -238,33 +291,28 @@ val summary = nextIntBetween(100, 500) @@ aspSummary
 Frequencies are used to count the occurrences of distinct string values. For example an application that uses logical
 names for its services, the number of invocations for each service can be tracked.
 
-Essentially, a Frequency is a set of related counters sharing the same name and tags. The counters are set
-apart from each other by an additional configurable tag. The values of the tag represent the observed
-distinct values.
+Essentially, a Frequency is a set of related counters sharing the same name and tags. The counters are set apart from
+each other by an additional configurable tag. The values of the tag represent the observed distinct values.
 
 To configure a frequency aspect, the name of the tag holding the distinct values must be configured.
 
-### API
-
-A metric aspect that counts the number of occurrences of each distinct
-value returned by the effect it is applied to.
+A frequency can be created with the `frequency` method:
 
 ```scala
-def frequency(name: String): Metric.Frequency[String]
+Metric.frequency(name: String): Metric.Frequency[String]
 ```
 
 ### Examples
 
-Create a Frequency to observe the occurrences of unique Strings.
-It can be applied to effects yielding a String.
+Create a Frequency to observe the occurrences of unique Strings. It can be applied to effects producing a String.
 
 ```scala
-val aspSet = Metric.frequency("mySet")
+val aspSet = Metric.frequency("my_set")
 ```  
 
 Now we can generate some keys within an effect and start counting the occurrences
 for each value.
 
 ```scala 
-val set = nextIntBetween(10, 20).map(v => s"myKey-$v") @@ aspSet
+val set = nextIntBetween(10, 20).map(v => s"my_key_$v") @@ aspSet
 ```

--- a/docs/metrics/prometheus-client.md
+++ b/docs/metrics/prometheus-client.md
@@ -3,180 +3,211 @@ id: prometheus-client
 title: Prometheus Client
 ---
 
-In a normal prometheus setup we will find prometheus agents which query configured endpoints 
-at regular intervals. The endpoints are HTTP endpoints serving the current metric state in 
-an encoding defined by [prometheus](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format).
+In a normal prometheus setup we will find prometheus agents which query configured endpoints at regular intervals. The
+endpoints are HTTP endpoints serving the current metric state in an encoding defined by
+[prometheus](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format).
 
-ZIO Metrics provides the Prometheus encoding for the captured metrics out of the box. To avoid enforcing 
-a particular HTTP implementation, an instrumented application needs to expose the encoded format 
-as an endpoint with the HTTP server of it´s choice. 
+ZIO Metrics Connectors provides the Prometheus encoding for the captured metrics out of the box. To avoid enforcing a
+particular HTTP implementation, an instrumented application needs to expose the encoded format as an endpoint with the
+HTTP server of its choice.
 
-## ZIO Metrics in Prometheus 
+## ZIO Metrics in Prometheus
 
-Most of the ZIO metrics have a direct representation in the Prometheus encoding. 
+Most of the ZIO metrics have a direct representation in the Prometheus encoding.
 
 ### Counter
 
-A counter is represented as a prometheus counter. 
+A counter is represented as a prometheus counter.
 
-```
-# TYPE countAll counter
-# HELP countAll 
-countAll 460.0 1623586224730
+```scala
+Metrics.counter("count_all", "The counter description.")
 ```
 
-### Gauge 
-
-A gauge is represented as a prometheus gauge. 
-
 ```
-# TYPE adjustGauge gauge
-# HELP adjustGauge 
-adjustGauge -1.2485836762095701 1623586224730
+# TYPE count_all counter
+# HELP count_all The counter description.
+count_all 460.0 1623586224730
 ```
 
-### Histogram 
+### Gauge
 
-A histogram is represented as a prometheus histogram. 
+A gauge is represented as a prometheus gauge.
 
-```
-# TYPE myHistogram histogram
-# HELP myHistogram 
-myHistogram{le="0.0"} 0.0 1623586224730
-myHistogram{le="10.0"} 8.0 1623586224730
-myHistogram{le="20.0"} 18.0 1623586224730
-myHistogram{le="30.0"} 30.0 1623586224730
-myHistogram{le="40.0"} 44.0 1623586224730
-myHistogram{le="50.0"} 51.0 1623586224730
-myHistogram{le="60.0"} 59.0 1623586224730
-myHistogram{le="70.0"} 65.0 1623586224730
-myHistogram{le="80.0"} 76.0 1623586224730
-myHistogram{le="90.0"} 88.0 1623586224730
-myHistogram{le="100.0"} 95.0 1623586224730
-myHistogram{le="+Inf"} 115.0 1623586224730
-myHistogram_sum 6828.578655207023 1623586224730
-myHistogram_count 115.0 1623586224730
+```scala
+Metrics.gauge("adjust_gauge", "The gauge description.")
 ```
 
-### Summary 
-
-A histogram is represented as a prometheus summary. 
-
 ```
-# TYPE mySummary summary
-# HELP mySummary 
-mySummary{quantile="0.1",error="0.03"} 147.0 1623589839194
-mySummary{quantile="0.5",error="0.03"} 286.0 1623589839194
-mySummary{quantile="0.9",error="0.03"} 470.0 1623589839194
-mySummary_sum 42582.0 1623589839194
-mySummary_count 139.0 1623589839194
+# TYPE adjust_gauge gauge
+# HELP adjust_gauge The gauge description.
+adjust_gauge -1.2485836762095701 1623586224730
 ```
 
-### Set 
+### Histogram
 
-A set is represented by a set of prometheus counters, distinguished from each other with an 
-extra label as configured in the aspect. 
+A histogram is represented as a prometheus histogram.
 
-```
-# TYPE mySet counter
-# HELP mySet 
-mySet{token="myKey-17"} 7.0 1623589839194
-mySet{token="myKey-18"} 9.0 1623589839194
-mySet{token="myKey-19"} 12.0 1623589839194
-mySet{token="myKey-13"} 6.0 1623589839194
-mySet{token="myKey-14"} 4.0 1623589839194
-mySet{token="myKey-15"} 6.0 1623589839194
-mySet{token="myKey-16"} 5.0 1623589839194
-mySet{token="myKey-10"} 10.0 1623589839194
-mySet{token="myKey-11"} 1.0 1623589839194
-mySet{token="myKey-12"} 10.0 1623589839194
+```scala
+Metrics.histogram(
+  "my_histogram",
+  "My histogram description.",
+  MetricKeyType.Histogram.Boundaries.linear(0.0, 10.0, 11)
+)
 ```
 
-## Serving Prometheus metrics
+```
+# TYPE my_histogram histogram
+# HELP my_histogram My histogram description.
+my_histogram{le="0.0"} 0.0 1623586224730
+my_histogram{le="10.0"} 8.0 1623586224730
+my_histogram{le="20.0"} 18.0 1623586224730
+my_histogram{le="30.0"} 30.0 1623586224730
+my_histogram{le="40.0"} 44.0 1623586224730
+my_histogram{le="50.0"} 51.0 1623586224730
+my_histogram{le="60.0"} 59.0 1623586224730
+my_histogram{le="70.0"} 65.0 1623586224730
+my_histogram{le="80.0"} 76.0 1623586224730
+my_histogram{le="90.0"} 88.0 1623586224730
+my_histogram{le="100.0"} 95.0 1623586224730
+my_histogram{le="+Inf"} 115.0 1623586224730
+my_histogram_sum 6828.578655207023 1623586224730
+my_histogram_count 115.0 1623586224730
+```
 
-```scala 
-import zio.http._
+### Summary
 
+A summary is represented as a prometheus summary.
+
+```scala
+Metric.summary(
+  "my_summary",
+  "The summary description.",
+  maxAge = ???,
+  maxSize = ???,
+  error = ???,
+  quantiles = Chunk(0.1, 0.5, 0.9),
+)
+```
+
+```
+# TYPE my_summary summary
+# HELP my_summary The summary description. 
+my_summary{quantile="0.1",error="0.03"} 147.0 1623589839194
+my_summary{quantile="0.5",error="0.03"} 286.0 1623589839194
+my_summary{quantile="0.9",error="0.03"} 470.0 1623589839194
+my_summary_sum 42582.0 1623589839194
+my_summary_count 139.0 1623589839194
+```
+
+### Frequency
+
+A frequency is represented by a set of prometheus counters, distinguished from each other with a label.
+
+```scala
+val aspSet = Metric.frequency("my_set", "My set description.")
+ZIO.succeed("my_key_10") @@ aspSet
+ZIO.succeed("my_key_11") @@ aspSet
+// etc.
+```
+
+```
+# TYPE my_set counter
+# HELP my_set My set description.
+my_set{token="my_key_17"} 7.0 1623589839194
+my_set{token="my_key_18"} 9.0 1623589839194
+my_set{token="my_key_19"} 12.0 1623589839194
+my_set{token="my_key_13"} 6.0 1623589839194
+my_set{token="my_key_14"} 4.0 1623589839194
+my_set{token="my_key_15"} 6.0 1623589839194
+my_set{token="my_key_16"} 5.0 1623589839194
+my_set{token="my_key_10"} 10.0 1623589839194
+my_set{token="my_key_11"} 1.0 1623589839194
+my_set{token="my_key_12"} 10.0 1623589839194
+```
+
+## Serving Prometheus metrics through HTTP
+
+ZIO Metrics Connectors provides a prometheus client that can be used to produce the prometheus encoded metric state upon
+request. The state is encoded and stored in the `PrometheusPublisher` class. To retrieve the prometheus encoded state,
+the application can use the `PrometheusPublisher#get` method:
+
+```scala
+val encodedContent: ZIO[PrometheusPublisher, Nothing, String] =
+   ZIO.serviceWithZIO[PrometheusPublisher](_.get)
+```
+
+The resulting string can then be used in an HTTP response that has a `Content-Type` header with value
+`text/plain; version=0.0.4` (just `text/plain` works for as long as Prometheus does not define a newer format).
+
+## Example HTTP server using zio-http
+
+This section shows some code fragments from the example application that is provided in the zio-metrics-connectors
+repository on GitHub. In the example we use [zio-http](https://github.com/zio/zio-http) (version `3.0.0-RC4`) to serve
+the metrics.
+
+```scala mdoc:invisible
 import zio._
-import zio.console._
+import zio.http._
 import zio.metrics.connectors.{prometheusLayer, publisherLayer}
-
-import sample.InstrumentedSample
-
-val instrumentedSample = new InstrumentedSample() {}
+import java.nio.charset.StandardCharsets
 ```
 
-ZIO Metrics connector provides a prometheus client that can be used to produce the prometheus encoded metric state 
-upon request. The state is encoded in the `PrometheusPublisher` case class and the single attribute of 
-type `Ref[String]` holds the prometheus encoded metric state. 
+First we define the metrics route:
 
-So, to retrieve the prometheus encoded state, the application can simply use `PrometheusPublisher#get` method:
 ```scala
-val encodedContent: UIO[String] = publisher.get
-```
-
-In our example application we use [zio-http](https://github.com/zio/zio-http) to serve the metrics. Other application might choose another HTTP server framework if required.
-
-```scala 
-private val metricsConfig = ZLayer.succeed(MetricsConfig(5.seconds))
-
-private lazy val indexPage =
-  """<html>
-    |<title>Simple Server</title>
-    |<body>
-    |<p><a href="/prometheus/metrics">Prometheus Metrics</a></p>
-    |<p><a href="/insight/keys">Insight Metrics: Get all keys</a></p>
-    |</body
-    |</html>""".stripMargin
-
-private lazy val static =
-  Http.collect[Request] { case Method.GET -> Root => Response.html(Html.fromString(indexPage)) }
-
-private lazy val prometheusRouter =
-  Http
-    .collectZIO[Request] { case Method.GET -> Root / "prometheus" / "metrics" =>
-      ZIO.serviceWithZIO[PrometheusPublisher](_.get.map(Response.text))
+val prometheusRoute: Route[PrometheusPublisher, Nothing] =
+  Method.GET / "metrics" -> handler {
+    ZIO.serviceWithZIO[PrometheusPublisher](_.get).map { response =>
+      Response(
+        status = Status.Ok,
+        headers = Headers(Header.Custom(Header.ContentType.name, "text/plain; version=0.0.4")),
+        body = Body.fromString(response, StandardCharsets.UTF_8)
+      )
     }
+  }
 ```
 
-Now, using the HTTP server and the [instrumentation examples](instrumentation-examples.md) we can create an effect 
-that simply runs the sample effects with their instrumentation. And within a `ZIO.App` we can override the run method,
-which is now simply the execute method with a Prometheus client provided in it´s environment:
+We convert the route to an `HttpApp` and create an HTTP server:
 
 ```scala
-  private val serverInstall =
-  Server.install(static ++ prometheusRouter)
-
-private lazy val runHttp = (serverInstall *> ZIO.never).forkDaemon
-
-private lazy val serverConfig = ZLayer.succeed(Server.Config.default.port(bindPort))
-
-override def run: ZIO[Environment & ZIOAppArgs & Scope, Any, Any] = (for {
-  f <- runHttp
-  _ <- program
-  _ <- f.join
-} yield ())
-  .provide(
-    serverConfig,
-    Server.live,
-
-    // This is the general config for all backends
-    metricsConfig,
-
-    // The prometheus reporting layer
-    prometheus.publisherLayer,
-    prometheus.prometheusLayer,
-
-    // Enable the ZIO internal metrics and the default JVM metricsConfig
-    // Do NOT forget the .unit for the JVM metrics layer
-    Runtime.enableRuntimeMetrics,
-    DefaultJvmMetrics.live.unit,
-  )
+val httpApp = prometheusRoute.toHttpApp
+val runHttp = (Server.serve(httpApp) *> ZIO.never).forkDaemon
+val serverConfig = ZLayer.succeed(Server.Config.default.port(8080))
 ```
 
-## Running the prometheus example 
+Now we can wire everything together in a ZIO app:
 
-Any of the examples can be run from a command line within the project checkout directory with 
+```scala
+object SamplePrometheusApp extends ZIOAppDefault {
+  // How often should the prometheus publisher update the response:
+  private val metricsConfig = ZLayer.succeed(MetricsConfig(5.seconds))
+
+   override def run: ZIO[Scope, Any, Any] = (for {
+      f <- runHttp
+      _ <- ZIO.sleep(1.minute) // Your program logic here
+      _ <- f.join
+   } yield ())
+     .provide(
+        serverConfig,
+        Server.live,
+
+        // The prometheus reporting layer
+        metricsConfig,
+        prometheus.publisherLayer,
+        prometheus.prometheusLayer,
+
+        // Enable the ZIO internal metrics and the default JVM metricsConfig
+        // Do NOT forget the .unit for the JVM metrics layer
+        Runtime.enableRuntimeMetrics,
+        DefaultJvmMetrics.live.unit,
+     )
+}
+```
+
+
+## Running the full example app
+
+Any of the examples can be run from a command line within the project checkout directory with:
 
 ```
 sbt sampleApp/run
@@ -184,56 +215,57 @@ sbt sampleApp/run
 
 Out of the choices, select the option corresponding to `sample.SamplePrometheusStatsDApp`.
 
-If everything works, we should be able to use a web browser to go to `http://localhost:8080/metrics` and should see something like 
+If everything works, we should be able to use a web browser and go to `http://localhost:8080/metrics` to see something
+like:
 
 ```
-# TYPE myCounter counter
-# HELP myCounter
-myCounter{effect="count2"} 46.0 1608982756235
-# TYPE setGauge gauge
-# HELP setGauge
-setGauge 8.66004641453435 1608982756235
-# TYPE changeGauge gauge
-# HELP changeGauge
-changeGauge 90.7178906485008 1608982756235
-# TYPE myCounter counter
-# HELP myCounter
-myCounter{effect="count1"} 92.0 1608982756235
+# TYPE my_counter counter
+# HELP my_counter
+my_counter{effect="count2"} 46.0 1608982756235
+# TYPE set_gauge gauge
+# HELP set_gauge
+set_gauge 8.66004641453435 1608982756235
+# TYPE change_gauge gauge
+# HELP change_gauge
+change_gauge 90.7178906485008 1608982756235
+# TYPE my_counter counter
+# HELP my_counter
+my_counter{effect="count1"} 92.0 1608982756235
 ```
 
-Once we see the metrics being served from our example, we can set up Prometheus and Grafana to create a simple dashboard displaying 
-our metrics. 
+Once we see the metrics being served from our example, we can set up Prometheus and Grafana to create a dashboard
+displaying our metrics.
 
-## Simple Prometheus setup 
+## Prometheus setup
 
-The following steps have been tested on Ubuntu 18.04 running inside the Windows Subsystem for Linux. 
-Essentially, you need to download the prometheus binaries for your environment and start the server 
-with our sample configuration located at 
+The following steps have been tested on Ubuntu 18.04 running inside the Windows Subsystem for Linux. Essentially, you
+need to download the prometheus binaries for your environment and start the server with our sample configuration located
+at
 
 ```
 ${PROJECT_HOME}/examples/prometheus/promcfg.yml
 ``` 
 
-This will just configure a prometheus job that regular polls `http://localhost:8080/metrics` for prometheus 
-encoded metrics.
+This will configure a prometheus job that regular polls `http://localhost:8080/metrics` for prometheus encoded metrics.
 
-In addition, you need to download the Grafana binaries for your installation, start the Grafana server and configure 
-prometheus as a single data source. 
+In addition, you need to download the Grafana binaries for your installation, start the Grafana server and configure
+prometheus as a single data source.
 
 Finally, you can import our example dashboard at `examples/prometheus/ZIOMetricsDashboard.json` and enjoy the results.
 
-> These steps are not intended to replace the Prometheus or Grafana documentation. Please refer to their web sites 
-> for guidelines towards a more sophisticated setup or an installation on different platforms. 
+> These steps are not intended to replace the Prometheus or Grafana documentation. Please refer to their websites for
+> guidelines towards a more sophisticated setup or an installation on different platforms.
 
 ---
 
-### Download and configure Prometheus 
+### Download and configure Prometheus
 
 In the steps below the project checkout directory will be referred to as `$DIR`.
 
-1. [Download](https://github.com/prometheus/prometheus/releases/download/v2.23.0/prometheus-2.23.0.linux-amd64.tar.gz) prometheus
-1. Extract the downloaded archive to a directory of your choice, this will be referred to as `$PROMDIR`. 
-1. Within `$PROMDIR` execute 
+1. [Download](https://github.com/prometheus/prometheus/releases/download/v2.23.0/prometheus-2.23.0.linux-amd64.tar.gz)
+   prometheus
+1. Extract the downloaded archive to a directory of your choice, this will be referred to as `$PROMDIR`.
+1. Within `$PROMDIR` execute
    ```
    ./prometheus --config.file $DIR/examples/prometheus/promcfg.yml
    ```
@@ -243,25 +275,25 @@ In the steps below the project checkout directory will be referred to as `$DIR`.
 
 1. [Download](https://dl.grafana.com/oss/release/grafana-7.3.6.linux-amd64.tar.gz) grafana
 1. Extract the downloaded archive to a directory of your choice, this will be referred to as `$GRAFANADIR`.
-1. Within `$GRAFANADIR` execute 
+1. Within `$GRAFANADIR` execute
    ```
    ./bin/grafana-server
    ```
    This will start a Grafana server.
-1. Now you should be able to login to Grafana at `http://localhost:3000' with the default user `admin` with the default 
-   password `admin`. 
+1. Now you should be able to login to Grafana at `http://localhost:3000' with the default user `admin` with the default
+   password `admin`.
 
-   Upon the first login you will be asked to change the default password. 
-1. Within the Grafana menu on the left hand side you will find `Manage Dashboards` within that page, select `Import`. 
-1. You can now either install a dashboard from grafana.com or use a text field to paste JSON. 
+   Upon the first login you will be asked to change the default password.
+1. Within the Grafana menu on the left hand side you will find `Manage Dashboards` within that page, select `Import`.
+1. You can now either install a dashboard from grafana.com or use a text field to paste JSON.
 1. Paste the content of `$DIR/examples/prometheus/ZIOMetricsDashboard.json` into the text field and select `Load`.
 
-   This will import our dashboard example. 
-1. Now, under `Manage Dashboards` the just imported ZIO dashboard should be visible. 
-1. Navigate to the dashboard. 
+   This will import our dashboard example.
+1. Now, under `Manage Dashboards` the just imported ZIO dashboard should be visible.
+1. Navigate to the dashboard.
 
-### Grafana dashboard 
+### Grafana dashboard
 
-Here is a screenshot of the Grafana dashboard produced with the setup above. 
+Here is a screenshot of the Grafana dashboard produced with the setup above.
 
 ![A simple Grafana Dashboard](../img/ZIOMetrics-Grafana.png)

--- a/docs/metrics/prometheus-client.md
+++ b/docs/metrics/prometheus-client.md
@@ -141,16 +141,10 @@ The resulting string can then be used in an HTTP response that has a `Content-Ty
 
 ## Example HTTP server using zio-http
 
-This section shows some code fragments from the example application that is provided in the zio-metrics-connectors
-repository on GitHub. In the example we use [zio-http](https://github.com/zio/zio-http) (version `3.0.0-RC4`) to serve
-the metrics.
-
-```scala mdoc:invisible
-import zio._
-import zio.http._
-import zio.metrics.connectors.{prometheusLayer, publisherLayer}
-import java.nio.charset.StandardCharsets
-```
+This section shows some code fragments from the
+[example application](https://github.com/zio/zio-metrics-connectors/blob/docs/sample-app/src/main/scala/sample/SamplePrometheusStatsDApp.scala)
+that is provided in the zio-metrics-connectors repository on GitHub. In the example we
+use [zio-http](https://github.com/zio/zio-http) (version `3.0.0-RC4`) to serve the metrics.
 
 First we define the metrics route:
 

--- a/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
+++ b/micrometer/src/main/scala/zio/metrics/connectors/micrometer/MicrometerMetricListener.scala
@@ -7,7 +7,7 @@ import java.util.function.{Function => JFunction}
 import scala.jdk.CollectionConverters._
 
 import zio.{Unsafe, URIO, ZIO}
-import zio.metrics.{MetricKey, MetricKeyType, MetricLabel, MetricListener}
+import zio.metrics.{MetricKey, MetricKeyType, MetricListener}
 import zio.metrics.connectors.micrometer.internal.AtomicDouble
 
 import io.micrometer.core.instrument.{Counter, DistributionSummary, Gauge => MGauge, MeterRegistry, Tag}

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -6,7 +6,7 @@ object Version {
 
   val zio     = "2.0.16"
   val zioJson = "0.5.0"
-  val zioHttp = "3.0.0-RC2"
+  val zioHttp = "3.0.0-RC4"
 
   val micrometer  = "1.11.0"
   val scalaCompat = "2.11.0"

--- a/sample-app/src/main/scala/sample/InstrumentedSample.scala
+++ b/sample-app/src/main/scala/sample/InstrumentedSample.scala
@@ -6,27 +6,29 @@ import zio.metrics._
 trait InstrumentedSample {
 
   // Create a gauge, it can be applied to effects yielding a Double
-  val aspGauge1 = Metric.gauge("gauge1").tagged("description", "Sample gauge1")
+  val aspGauge1 = Metric.gauge("gauge1", "Description of gauge1")
+    .tagged("tag1", "tag value")
+    .tagged("tag2", "anoter tag value")
 
   val aspGauge2 = Metric.gauge("gauge2")
 
   // Create a histogram with 12 buckets: 0..100 in steps of 10, Infinite
   // It also can be applied to effects yielding a Double
   val aspHistogram =
-    Metric.histogram("myHistogram", MetricKeyType.Histogram.Boundaries.linear(0.0d, 10.0d, 11))
+    Metric.histogram("my_histogram", MetricKeyType.Histogram.Boundaries.linear(0.0d, 10.0d, 11))
 
   // Create a summary that can hold 100 samples, the max age of the samples is 1 day.
   // The summary should report th 10%, 50% and 90% Quantile
   // It can be applied to effects yielding an Int
   val aspSummary =
-    Metric.summary("mySummary", 1.day, 100, 0.03d, Chunk(0.1, 0.5, 0.9)).contramap[Int](_.toDouble)
+    Metric.summary("my_summary", 1.day, 100, 0.03d, Chunk(0.1, 0.5, 0.9)).contramap[Int](_.toDouble)
 
   // Create a Set to observe the occurrences of unique Strings
   // It can be applied to effects yielding a String
-  val aspSet = Metric.frequency("mySet")
+  val aspSet = Metric.frequency("my_set")
 
   // Create a counter applicable to any effect
-  val aspCountAll = Metric.counter("countAll").contramap[Any](_ => 1L)
+  val aspCountAll = Metric.counter("count_all").contramap[Any](_ => 1L)
 
   private lazy val gaugeSomething = for {
     _ <- Random.nextDoubleBetween(0.0d, 100.0d) @@ aspGauge1 @@ aspCountAll
@@ -41,7 +43,7 @@ trait InstrumentedSample {
 
   // Observe Strings in order to capture unique values
   private lazy val observeKey = for {
-    _ <- Random.nextIntBetween(10, 20).map(v => s"myKey-$v") @@ aspSet @@ aspCountAll
+    _ <- Random.nextIntBetween(10, 20).map(v => s"my_key_$v") @@ aspSet @@ aspCountAll
   } yield ()
 
   def program: ZIO[Any, Nothing, Unit] = for {

--- a/sample-app/src/main/scala/sample/SamplePrometheusStatsDApp.scala
+++ b/sample-app/src/main/scala/sample/SamplePrometheusStatsDApp.scala
@@ -2,11 +2,13 @@ package sample
 
 import zio._
 import zio.http._
-import zio.http.html._
-import zio.metrics.connectors.{prometheus, statsd, MetricsConfig}
+import zio.http.template.{Dom, Html}
+import zio.metrics.connectors.{MetricsConfig, prometheus, statsd}
 import zio.metrics.connectors.prometheus.PrometheusPublisher
 import zio.metrics.connectors.statsd.StatsdConfig
 import zio.metrics.jvm.DefaultJvmMetrics
+
+import java.nio.charset.StandardCharsets
 
 /**
  * This is a sample app that shows how to use the Prometheus and StatsD connectors.
@@ -21,27 +23,33 @@ object SamplePrometheusStatsDApp extends ZIOAppDefault with InstrumentedSample {
     """<html>
       |<title>Simple Server</title>
       |<body>
-      |<p><a href="/prometheus/metrics">Prometheus Metrics</a></p>
-      |<p><a href="/insight/keys">Insight Metrics: Get all keys</a></p>
+      |<p><a href="/metrics">Prometheus Metrics</a></p>
       |</body
       |</html>""".stripMargin
 
-  private lazy val static =
-    Http.collect[Request] { case Method.GET -> Root => Response.html(Html.fromString(indexPage)) }
+  private lazy val staticRoute: Route[Any, Nothing] =
+    Method.GET / "" -> handler(Response.html(Html.fromDomElement(Dom.raw(indexPage))))
 
-  private lazy val prometheusRouter =
-    Http
-      .collectZIO[Request] { case Method.GET -> Root / "prometheus" / "metrics" =>
-        ZIO.serviceWithZIO[PrometheusPublisher](_.get.map(Response.text))
+  private lazy val prometheusRoute: Route[PrometheusPublisher, Nothing] =
+    Method.GET / "metrics" -> handler {
+      ZIO.serviceWithZIO[PrometheusPublisher](_.get).map { response =>
+        noCors(
+          Response(
+            status = Status.Ok,
+            headers = Headers(Header.Custom(Header.ContentType.name, "text/plain; version=0.0.4")),
+            body = Body.fromString(response, StandardCharsets.UTF_8)
+          )
+        )
       }
+    }
 
   private def noCors(r: Response): Response =
     r.updateHeaders(_.combine(Headers(("Access-Control-Allow-Origin", "*"))))
 
-  private val serverInstall =
-    Server.install(static ++ prometheusRouter)
+  private val httpApp: HttpApp[PrometheusPublisher] =
+    Routes(staticRoute, prometheusRoute).toHttpApp
 
-  private lazy val runHttp = (serverInstall *> ZIO.never).forkDaemon
+  private lazy val runHttp = (Server.serve(httpApp) *> ZIO.never).forkDaemon
 
   private lazy val serverConfig = ZLayer.succeed(Server.Config.default.port(bindPort))
 


### PR DESCRIPTION
Extends the documentation, filling in some gaps while trying to use the scala [inclusive-language-guide](https://docs.scala-lang.org/contribute/inclusive-language-guide.html).

Updates the examples to zio-http 3.0.0-RC4. The datadog client was not updated to RC4.

Change names and labels to snake case as recommended by Prometheus.