### PR TITLE
Implement ability to override the StatsdClient

### DIFF
--- a/datadog/src/main/scala/zio/metrics/connectors/datadog/DatadogConfig.scala
+++ b/datadog/src/main/scala/zio/metrics/connectors/datadog/DatadogConfig.scala
@@ -1,8 +1,9 @@
 package zio.metrics.connectors.datadog
 
-import java.time.Duration
+import zio.metrics.connectors.statsd.StatsdClientIpConfig
 
-import zio.{ULayer, ZLayer}
+import java.time.Duration
+import zio.{&, ULayer, ZLayer}
 
 /**
  * Datadog Specific configuration
@@ -32,7 +33,7 @@ final case class DatadogConfig(
   maxQueueSize: Int = 100000,
   containerId: Option[String] = None,
   entityId: Option[String] = None,
-  sendUnchanged: Boolean = false)
+  sendUnchanged: Boolean = false) extends StatsdClientIpConfig
 
 object DatadogConfig {
 
@@ -43,5 +44,5 @@ object DatadogConfig {
       histogramSendInterval = None,
     )
 
-  val defaultLayer: ULayer[DatadogConfig] = ZLayer.succeed(default)
+  val defaultLayer: ULayer[DatadogConfig & StatsdClientIpConfig] = ZLayer.succeed(default)
 }

--- a/datadog/src/main/scala/zio/metrics/connectors/datadog/package.scala
+++ b/datadog/src/main/scala/zio/metrics/connectors/datadog/package.scala
@@ -4,15 +4,15 @@ import zio._
 import zio.internal.RingBuffer
 import zio.metrics.{MetricClient, MetricKey, MetricKeyType}
 import zio.metrics.connectors.internal.MetricsClient
-import zio.metrics.connectors.statsd.{StatsdClient, StatsdConfig}
+import zio.metrics.connectors.statsd.StatsdClient
 
 package object datadog {
 
-  lazy val datadogLayer: ZLayer[DatadogConfig & MetricsConfig, Nothing, Unit] =
+  lazy val datadogLayer: ZLayer[DatadogConfig & MetricsConfig & StatsdClient, Nothing, Unit] =
     ZLayer.scoped(
       for {
         config  <- ZIO.service[DatadogConfig]
-        clt     <- StatsdClient.make.provideSome[Scope](ZLayer.succeed(StatsdConfig(config.host, config.port)))
+        clt     <- ZIO.service[StatsdClient]
         queue    = RingBuffer.apply[(MetricKey[MetricKeyType.Histogram], Double)](config.maxQueueSize)
         listener = new DataDogListener(queue)
         _       <- Unsafe.unsafe(unsafe =>

--- a/sample-app/src/main/scala/sample/SamplePrometheusStatsDApp.scala
+++ b/sample-app/src/main/scala/sample/SamplePrometheusStatsDApp.scala
@@ -5,7 +5,7 @@ import zio.http._
 import zio.http.template.{Dom, Html}
 import zio.metrics.connectors.{MetricsConfig, prometheus, statsd}
 import zio.metrics.connectors.prometheus.PrometheusPublisher
-import zio.metrics.connectors.statsd.StatsdConfig
+import zio.metrics.connectors.statsd.StatsdIpConfig
 import zio.metrics.jvm.DefaultJvmMetrics
 
 import java.nio.charset.StandardCharsets
@@ -70,7 +70,7 @@ object SamplePrometheusStatsDApp extends ZIOAppDefault with InstrumentedSample {
       prometheus.prometheusLayer,
 
       // The statsd reporting layer
-      ZLayer.succeed(StatsdConfig("127.0.0.1", 8125)),
+      ZLayer.succeed(StatsdIpConfig("127.0.0.1", 8125)),
       statsd.statsdLayer,
 
       // Enable the ZIO internal metrics and the default JVM metricsConfig

--- a/statsd/src/main/scala/zio/metrics/connectors/statsd/StatsdClient.scala
+++ b/statsd/src/main/scala/zio/metrics/connectors/statsd/StatsdClient.scala
@@ -42,7 +42,10 @@ private[connectors] object StatsdClient {
   private[connectors] def make: ZIO[Scope & StatsdConfig, Nothing, StatsdClient] =
     for {
       config  <- ZIO.service[StatsdConfig]
-      channel <- channelZIO(config.host, config.port).orDie
+      channel <- config match {
+        case c: StatsdClientIpConfig => channelZIO(c.host, c.port).orDie
+        case other => ZIO.dieMessage(s"Unknown configuration type: ${other.getClass.getName}")
+      }
       client   = new Live(channel)
     } yield client
 

--- a/statsd/src/main/scala/zio/metrics/connectors/statsd/StatsdConfig.scala
+++ b/statsd/src/main/scala/zio/metrics/connectors/statsd/StatsdConfig.scala
@@ -2,14 +2,19 @@ package zio.metrics.connectors.statsd
 
 import zio.{ULayer, _}
 
-final case class StatsdConfig(
-  host: String,
-  port: Int)
+trait StatsdConfig
+
+trait StatsdClientIpConfig extends StatsdConfig {
+  val host: String
+  val port: Int
+}
+
+case class StatsdIpConfig(host: String, port: Int) extends StatsdClientIpConfig
 
 object StatsdConfig {
 
-  val default: StatsdConfig =
-    StatsdConfig("localhost", 8125)
+  val default: StatsdClientIpConfig =
+    StatsdIpConfig("localhost", 8125)
 
   val defaultLayer: ULayer[StatsdConfig] = ZLayer.succeed(default)
 }


### PR DESCRIPTION

This is an architectural change that can simplify the implementation of the DataDog metrics through the Unix Domain socket.

In the current implementation, the `datadogLayer` creates its own instance of the `StatsdClient`, instead of obtaining it from the ZIO environment. This results in the DataDog layer being highly coupled with the StatsdClient implementation, and it subsequently becomes impossible to use the `StatsdClient` with a different configuration.

This PR introduces the following changes:
- The class `StatsdConfig` has been renamed to `StatsdIpConfig` in order to differentiate it from the forthcoming configuration model.
- A new trait, `StatsdConfig`, has been introduced. This should be consumed by the StatsdClient instances, replacing the concrete class.
- The `StatsdClientIpConfig` trait has also been introduced, serving as an abstraction layer between the DataDog configuration and the Statsd configuration.
- The `datadogLayer` no longer creates its own instance of `StatsdClient`; instead, it obtains the instance provided by the ZIO environment.
- DatadogConfig now implements `StatsdClientIpConfig`. This adjustment is necessary for the `StatsdClient` configuration to use `DataDogConfig` in place of `StatsdIpConfig`.

**NOTE**: This pull request introduces a breaking change for DataDog users. They are now required to provide the `StatsdClient` in the environment of the `datadogLayer`.