### PR TITLE
Replace `.forkDaemon` by `.forkScoped` in `MetricsClient.run`

### DIFF
--- a/core/src/main/scala/zio/metrics/connectors/internal/MetricsClient.scala
+++ b/core/src/main/scala/zio/metrics/connectors/internal/MetricsClient.scala
@@ -9,7 +9,7 @@ import zio.metrics.connectors._
 
 object MetricsClient {
 
-  def make(handler: Iterable[MetricEvent] => UIO[Unit]): ZIO[MetricsConfig, Nothing, Unit] =
+  def make(handler: Iterable[MetricEvent] => UIO[Unit]): ZIO[MetricsConfig & Scope, Nothing, Unit] =
     for {
       cfg   <- ZIO.service[MetricsConfig]
       state <- Ref.make[Set[MetricPair.Untyped]](Set.empty)
@@ -69,10 +69,10 @@ sealed abstract private class MetricsClient(
     builder.result()
   }
 
-  private def run(implicit trace: Trace): UIO[Unit] =
+  private def run(implicit trace: Trace): URIO[Scope, Unit] =
     update
       .schedule(Schedule.duration(10.millis) ++ Schedule.fixed(metricsCfg.interval))
-      .forkDaemon
+      .forkScoped
       .unit
 
 }

--- a/newrelic/src/main/scala/zio/metrics/connectors/newrelic/package.scala
+++ b/newrelic/src/main/scala/zio/metrics/connectors/newrelic/package.scala
@@ -12,12 +12,15 @@ package object newrelic {
       Client.default.orDie,
     )
 
-  private lazy val make: URLayer[MetricsConfig & NewRelicConfig & Client, Unit] = ZLayer(for {
-    encoder <- newRelicEncoder
-    client  <- NewRelicClient.make
-    handler  = newRelicHandler(encoder, client)
-    _       <- MetricsClient.make(handler)
-  } yield ())
+  private lazy val make: URLayer[MetricsConfig & NewRelicConfig & Client, Unit] =
+    ZLayer.scoped {
+      for {
+        encoder <- newRelicEncoder
+        client  <- NewRelicClient.make
+        handler  = newRelicHandler(encoder, client)
+        _       <- MetricsClient.make(handler)
+      } yield ()
+    }
 
   private lazy val newRelicEncoder =
     Clock.instant.map(NewRelicEncoder.apply)

--- a/prometheus/src/main/scala/zio/metrics/connectors/prometheus/package.scala
+++ b/prometheus/src/main/scala/zio/metrics/connectors/prometheus/package.scala
@@ -5,15 +5,15 @@ import zio.metrics.connectors.internal.MetricsClient
 
 package object prometheus {
 
-  lazy val publisherLayer: ULayer[PrometheusPublisher] = ZLayer.fromZIO(PrometheusPublisher.make)
+  val publisherLayer: ULayer[PrometheusPublisher] = ZLayer.fromZIO(PrometheusPublisher.make)
 
-  lazy val prometheusLayer: ZLayer[MetricsConfig & PrometheusPublisher, Nothing, Unit] =
-    ZLayer.fromZIO(
+  val prometheusLayer: ZLayer[MetricsConfig & PrometheusPublisher, Nothing, Unit] =
+    ZLayer.scoped {
       for {
         pub <- ZIO.service[PrometheusPublisher]
         _   <- MetricsClient.make(prometheusHandler(pub))
-      } yield (),
-    )
+      } yield ()
+    }
 
   private def prometheusHandler(clt: PrometheusPublisher): Iterable[MetricEvent] => UIO[Unit] =
     events =>
@@ -28,7 +28,7 @@ package object prometheus {
         _              <- clt.set(groupedReport.flatten.addString(new StringBuilder(old.length), "\n").toString())
       } yield ()
 
-  def groupMetricByType(report: Chunk[Chunk[String]]): Chunk[Chunk[String]] =
+  private[connectors] def groupMetricByType(report: Chunk[Chunk[String]]): Chunk[Chunk[String]] =
     Chunk.fromIterable(report.groupBy(thm => thm.take(2)).map { case (th, thmChunk) =>
       th ++ thmChunk.map(_.drop(2)).flatten
     })


### PR DESCRIPTION
Inspired by https://github.com/zio/zio-metrics-connectors/pull/74

These changes will require a minor version upgrade: `2.5.0`
Same as https://github.com/zio/zio-metrics-connectors/pull/103