### PR TITLE
Fix new statsd layers

### DIFF
--- a/statsd/src/main/scala/zio/metrics/connectors/statsd/package.scala
+++ b/statsd/src/main/scala/zio/metrics/connectors/statsd/package.scala
@@ -7,47 +7,42 @@ package object statsd {
 
   @deprecated("Use the statsdUDP or statsdUDS from the zio.metrics.connectors.statsd package instead", "2.4.0")
   lazy val statsdLayer: ZLayer[StatsdConfig & MetricsConfig, Nothing, Unit] =
-    ZLayer.scoped(
-      StatsdClient.make.flatMap(clt => MetricsClient.make(statsdHandler(clt))).unit,
-    )
+    ZLayer.scoped[StatsdConfig & MetricsConfig] {
+      StatsdClient.make.flatMap(metricsClient)
+    }
 
   /**
    * Creates a layer that provides a StatsdClient that sends metrics over UDP network protocol.
    */
-  lazy val statsdUDP: ZLayer[StatsdConfig & MetricsConfig, Nothing, StatsdClient] =
-    ZLayer.scoped {
-      for {
-        config <- ZIO.service[StatsdConfig]
-        client <- StatsdClient.make.provideSome[Scope](ZLayer.succeed(config))
-      } yield client
+  lazy val statsdUDP: URLayer[StatsdConfig & MetricsConfig, Unit] =
+    ZLayer.scoped[StatsdConfig & MetricsConfig] {
+      StatsdClient.make.flatMap(metricsClient)
     }
 
   /**
    * Creates a layer that provides a StatsdClient that sends metrics over unix domain socket (UDS).
    */
-  lazy val statsdUDS: ZLayer[DatagramSocketConfig & MetricsConfig, Nothing, StatsdClient] =
-    ZLayer.scoped {
-      for {
-        config <- ZIO.service[DatagramSocketConfig]
-        client <- DatagramSocketClient.make.provideSome[Scope](ZLayer.succeed(config))
-      } yield client
+  lazy val statsdUDS: URLayer[DatagramSocketConfig & MetricsConfig, Unit] =
+    ZLayer.scoped[DatagramSocketConfig & MetricsConfig] {
+      DatagramSocketClient.make.flatMap(metricsClient)
     }
 
-  private[connectors] def statsdHandler(clt: StatsdClient): Iterable[MetricEvent] => UIO[Unit] = events => {
-    val evtFilter: MetricEvent => Boolean = {
-      case MetricEvent.Unchanged(_, _, _) => false
-      case _                              => true
+  private def metricsClient(client: StatsdClient): URIO[MetricsConfig & Scope, Unit] =
+    MetricsClient.make { events =>
+      val evtFilter: MetricEvent => Boolean = {
+        case MetricEvent.Unchanged(_, _, _) => false
+        case _                              => true
+      }
+
+      val send = ZIO
+        .foreachDiscard(events.filter(evtFilter))(evt =>
+          for {
+            encoded <- StatsdEncoder.encode(evt).catchAll(_ => ZIO.succeed(Chunk.empty))
+            _       <- ZIO.when(encoded.nonEmpty)(ZIO.attempt(client.send(encoded)))
+          } yield (),
+        )
+
+      // TODO: Do we want to at least log a problem sending the metrics ?
+      send.catchAll(_ => ZIO.unit)
     }
-
-    val send = ZIO
-      .foreachDiscard(events.filter(evtFilter))(evt =>
-        for {
-          encoded <- StatsdEncoder.encode(evt).catchAll(_ => ZIO.succeed(Chunk.empty))
-          _       <- ZIO.when(encoded.nonEmpty)(ZIO.attempt(clt.send(encoded)))
-        } yield (),
-      )
-
-    // TODO: Do we want to at least log a problem sending the metrics ?
-    send.catchAll(_ => ZIO.unit)
-  }
 }


### PR DESCRIPTION
The recently added (and not deprecated) layers previously provided a StatsdClient, but did not wire them into MetricsClient. This has been fixed. Plus:

Refactored the statsd package to unify the creation of StatsdClient layers by introducing a private helper method `metricsClient` that handles metric event processing and sending (inlining statsdHandler into it). This reduces code duplication across `statsdLayer`, `statsdUDP`, and `statsdUDS` layers.

Additionally, changed the output type of these layers to `Unit` to better represent their effectful nature rather than exposing the client directly.