### PR TITLE
escapes the label values for Prometheus

### DIFF
--- a/prometheus/src/main/scala/zio/metrics/connectors/prometheus/PrometheusEncoder.scala
+++ b/prometheus/src/main/scala/zio/metrics/connectors/prometheus/PrometheusEncoder.scala
@@ -50,9 +50,10 @@ case object PrometheusEncoder {
         val iterator     = allLabels.iterator
         while (iterator.hasNext) {
           val l = iterator.next()
+          val v = l.value.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
           if (notFirstLoop) sb.append(",")
           notFirstLoop = true
-          sb.append(l.key).append("=\"").append(l.value).append("\"")
+          sb.append(l.key).append("=\"").append(v).append("\"")
         }
         sb.append("}")
         sb.toString

--- a/prometheus/src/test/scala/zio/metrics/connectors/prometheus/PrometheusEncoderSpec.scala
+++ b/prometheus/src/test/scala/zio/metrics/connectors/prometheus/PrometheusEncoderSpec.scala
@@ -17,6 +17,7 @@ object PrometheusEncoderSpec extends ZIOSpecDefault with Generators {
         encodeFrequency,
         encodeSummary,
         encodeHistogram,
+        encodeLabelEscaping,
       ) @@ timed @@ timeoutWarning(60.seconds) @@ parallel @@ withLiveClock
 
   def testGroupMetricByType = suite("The groupMetricByType method should")(
@@ -171,4 +172,21 @@ object PrometheusEncoderSpec extends ZIOSpecDefault with Generators {
       ),
     )
   })
+
+  private val encodeLabelEscaping = test("Escape special characters in label values") {
+    val key = MetricKey.counter("test_metric").tagged(
+      MetricLabel("label_with_backslash", "value\\with\\backslash"),
+      MetricLabel("label_with_quote", "value\"with\"quote"),
+      MetricLabel("label_with_newline", "value\nwith\nnewline"),
+    )
+    for {
+      timestamp <- Clock.instant
+      text      <- PrometheusEncoder.encode(New(key, MetricState.Counter(1.0), timestamp))
+      output     = text.mkString("\n")
+    } yield assertTrue(
+      output.contains("""label_with_backslash="value\\with\\backslash"""") &&
+        output.contains("""label_with_quote="value\"with\"quote"""") &&
+        output.contains("""label_with_newline="value\nwith\nnewline""""),
+    )
+  }
 }


### PR DESCRIPTION
This pull request improves the Prometheus metrics encoding by ensuring that special characters in label values are properly escaped, and adds a corresponding test to verify this behavior. 

This should fix https://github.com/zio/zio-metrics-connectors/issues/131
 
> label_value can be any sequence of UTF-8 characters, but the backslash (\), double-quote ("), and line feed (\n) characters have to be escaped as \\, \", and \n, respectively

See:
https://prometheus.io/docs/instrumenting/exposition_formats/
