### PR TITLE
Fix #153 - statsd client is not provided into the ZIO environment

### DIFF
--- a/statsd/src/main/scala/zio/metrics/connectors/statsd/package.scala
+++ b/statsd/src/main/scala/zio/metrics/connectors/statsd/package.scala
@@ -14,17 +14,25 @@ package object statsd {
   /**
    * Creates a layer that provides a StatsdClient that sends metrics over UDP network protocol.
    */
-  def statsdUDP: URLayer[StatsdConfig & MetricsConfig, Unit] =
+  def statsdUDP: URLayer[StatsdConfig & MetricsConfig, StatsdClient] =
     ZLayer.scoped[StatsdConfig & MetricsConfig] {
-      StatsdClient.make.flatMap(metricsClient)
+      StatsdClient.make.flatMap { statsdClient =>
+        for {
+          _ <- metricsClient(statsdClient)
+        } yield statsdClient
+      }
     }
 
   /**
    * Creates a layer that provides a StatsdClient that sends metrics over unix domain socket (UDS).
    */
-  def statsdUDS: URLayer[DatagramSocketConfig & MetricsConfig, Unit] =
+  def statsdUDS: URLayer[DatagramSocketConfig & MetricsConfig, StatsdClient] =
     ZLayer.scoped[DatagramSocketConfig & MetricsConfig] {
-      DatagramSocketClient.make.flatMap(metricsClient)
+      DatagramSocketClient.make.flatMap { statsdClient =>
+        for {
+          _ <- metricsClient(statsdClient)
+        } yield statsdClient
+      }
     }
 
   private def metricsClient(client: StatsdClient): URIO[MetricsConfig & Scope, Unit] =


### PR DESCRIPTION
The recently merged PR https://github.com/zio/zio-metrics-connectors/pull/141 changed return type of `statsdUDP` and `statsdUDS` from `StatsdClient` to `Unit` which breaks existing codes, like the DataDog example: https://zio.dev/zio-metrics-connectors/metrics/datadog-client/#the-zio-metrics-datadog-example 

This PR changes the return type of the mentioned layers back to `StatsdClient`.