### PR TITLE
Fix +Inf bucket inconsistency in PrometheusEncoder

### DIFF
--- a/prometheus/src/main/scala/zio/metrics/connectors/prometheus/PrometheusEncoder.scala
+++ b/prometheus/src/main/scala/zio/metrics/connectors/prometheus/PrometheusEncoder.scala
@@ -102,8 +102,7 @@ case object PrometheusEncoder {
         min = h.min,
         max = h.max,
         buckets = h.buckets.sortBy(_._1).map { case (le, v) =>
-          val label = if (le == Double.MaxValue) { "+Inf" }
-          else { String.valueOf(le) }
+          val label = if (le == Double.MaxValue) "+Inf" else String.valueOf(le)
           (
             Set(MetricLabel("le", label)),
             Some(v.doubleValue()),

--- a/prometheus/src/main/scala/zio/metrics/connectors/prometheus/PrometheusEncoder.scala
+++ b/prometheus/src/main/scala/zio/metrics/connectors/prometheus/PrometheusEncoder.scala
@@ -101,15 +101,14 @@ case object PrometheusEncoder {
         sum = h.sum,
         min = h.min,
         max = h.max,
-        buckets = h.buckets
-          .filter(_._1 != Double.MaxValue)
-          .sortBy(_._1)
-          .map { s =>
-            (
-              Set(MetricLabel("le", String.valueOf(s._1))),
-              Some(s._2.doubleValue()),
-            )
-          } :+ (Set(MetricLabel("le", "+Inf")) -> Some(h.count.doubleValue())),
+        buckets = h.buckets.sortBy(_._1).map { case (le, v) =>
+          val label = if (le == Double.MaxValue) { "+Inf" }
+          else { String.valueOf(le) }
+          (
+            Set(MetricLabel("le", label)),
+            Some(v.doubleValue()),
+          )
+        },
       )
 
     def sampleSummary(s: MetricState.Summary): SampleResult =

--- a/prometheus/src/test/scala/zio/metrics/connectors/prometheus/PrometheusEncoderSpec.scala
+++ b/prometheus/src/test/scala/zio/metrics/connectors/prometheus/PrometheusEncoderSpec.scala
@@ -144,13 +144,14 @@ object PrometheusEncoderSpec extends ZIOSpecDefault with Generators {
 
   private val encodeHistogram = test("Encode a Histogram")(check(genHistogram) { case (pair, state) =>
     for {
-      timestamp    <- ZIO.clockWith(_.instant)
-      text         <- PrometheusEncoder.encode(New(pair.metricKey, state, timestamp))
-      name          = pair.metricKey.name
-      epochMilli    = timestamp.toEpochMilli
-      help          = helpString(pair.metricKey)
-      labels        = labelString(pair.metricKey)
-      labelsWithInf = labelString(pair.metricKey, "le" -> "+Inf")
+      timestamp     <- ZIO.clockWith(_.instant)
+      text          <- PrometheusEncoder.encode(New(pair.metricKey, state, timestamp))
+      name           = pair.metricKey.name
+      epochMilli     = timestamp.toEpochMilli
+      help           = helpString(pair.metricKey)
+      labels         = labelString(pair.metricKey)
+      labelsWithInf  = labelString(pair.metricKey, "le" -> "+Inf")
+      infBucketValue = state.buckets.sortBy(_._1).lastOption.fold(0.0)(_._2.doubleValue())
     } yield assertTrue(
       text == Chunk(
         s"# TYPE $name histogram",
@@ -162,7 +163,7 @@ object PrometheusEncoderSpec extends ZIOSpecDefault with Generators {
             val labelsWithExtra = labelString(pair.metricKey, "le" -> k.toString)
             s"""${name}_bucket$labelsWithExtra ${v.toDouble} $epochMilli\n"""
           }
-          ++ s"""${name}_bucket$labelsWithInf ${state.count.toDouble} $epochMilli\n""").mkString,
+          ++ s"""${name}_bucket$labelsWithInf $infBucketValue $epochMilli\n""").mkString,
       ) ++ Chunk(
         s"${name}_sum$labels ${state.sum} $epochMilli",
         s"${name}_count$labels ${state.count.toDouble} $epochMilli",


### PR DESCRIPTION
Fixed #214. 

Different parts of the snapshot (`MetricState.Histogram`) can be inconsistent, but if we only use `buckets` to build the `_bucket` metric, at least the histogram visualization won't have artifacts.

It may still happen that `X_bucket{le="+Inf"}` is not equal to `X_count`. It is possible to fix this by ignoring the `count` from the snapshot and using the last bucket value, but I feel like consistency between different metrics is less critical. Also, we anyway cannot really guarantee anything about other metrics (`X_sum`, `X_min` and `X_max`).